### PR TITLE
configury: need dummy module incase gnulib has no other objects

### DIFF
--- a/bootstrap.conf
+++ b/bootstrap.conf
@@ -26,7 +26,6 @@
 # Additional gnulib-tool options to use.
 gnulib_tool_options='
         --no-changelog
-	--avoid=dummy
 '
 
 # gnulib modules used by this package.


### PR DESCRIPTION
It's only safe to use --avoid=dummy when there will never be a libgnu.a
built, i.e there are no other modules with C code, and thus the parent
project is never linked with libgnu.
