### PR TITLE
configury: no m4 quotes in configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -77,7 +77,7 @@ AC_HEADER_STDC
 
 dnl Compiler flags for POSIX
 dnl Get this from autotools/gnulib
-if [ `uname` = Darwin ]; then
+if test Darwin = `uname`; then
   POSIX_EXTRA_CFLAGS=-D_POSIX_C_SOURCE
 else
   # FIXME: Make -lrt conditional on _XOPEN_REALTIME


### PR DESCRIPTION
Also, for the sake of forming good habits, keep the lvalue on the left
of a comparison, and avoid the potential for uname returning something
that test might interpret as an argument.
