### PR TITLE
Add function fnmatch()

### DIFF
--- a/lposix.c
+++ b/lposix.c
@@ -23,6 +23,7 @@
 #include <dirent.h>
 #include <errno.h>
 #include <fcntl.h>
+#include <fnmatch.h>
 #include <getopt.h>
 #include <glob.h>
 #include <grp.h>
@@ -440,6 +441,24 @@ static int Pdir(lua_State *L)			/** dir([path]) */
 		lua_pushinteger(L, i-1);
 		return 2;
 	}
+}
+
+static int Pfnmatch(lua_State *L)     /** fnmatch(pattern, string [,flags]) */
+{
+	const char *pattern = lua_tostring(L, 1);
+	const char *string = lua_tostring(L, 2);
+	int flags = luaL_optint(L, 3, 0);
+	int res = fnmatch(pattern, string, flags);
+	if (res == 0)
+		lua_pushboolean(L, 1);
+	else if (res == FNM_NOMATCH)
+		lua_pushboolean(L, 0);
+	else
+	{
+		lua_pushstring(L, "fnmatch failed");
+		lua_error(L);
+	}
+	return 1;
 }
 
 static int Pglob(lua_State *L)                  /** glob(pattern) */
@@ -2089,6 +2108,7 @@ static const luaL_Reg R[] =
 	{"fcntl",		Pfcntl},
 	{"fileno",		Pfileno},
 	{"files",		Pfiles},
+	{"fnmatch",		Pfnmatch},
 	{"fork",		Pfork},
 	{"getcwd",		Pgetcwd},
 	{"getenv",		Pgetenv},
@@ -2325,6 +2345,22 @@ LUALIB_API int luaopen_posix_c (lua_State *L)
 	set_const("F_SETLKW", F_SETLKW);
 	set_const("F_GETOWN", F_GETOWN);
 	set_const("F_SETOWN", F_SETOWN);
+
+	/* from fnmatch.h */
+	set_const("FNM_PATHNAME", FNM_PATHNAME);
+	set_const("FNM_NOESCAPE", FNM_NOESCAPE);
+	set_const("FNM_PERIOD", FNM_PERIOD);
+
+	/* GNU extensions for fnmatch.h */
+#ifdef FNM_FILE_NAME
+	set_const("FNM_FILE_NAME", FNM_FILE_NAME);
+#endif
+#ifdef FNM_LEADING_DIR
+	set_const("FNM_LEADING_DIR", FNM_LEADING_DIR);
+#endif
+#ifdef FNM_CASEFOLD
+	set_const("FNM_CASEFOLD", FNM_CASEFOLD);
+#endif
 
 	/* Signals table */
 	lua_newtable(L);

--- a/tests-posix.lua
+++ b/tests-posix.lua
@@ -101,6 +101,17 @@ for f in ox.files"." do
   local g=assert(ox.getgroup(T.gid))
   print(T.mode,p.name.."/"..g.name,T.size,os.date("%b %d %H:%M",T.mtime),f,T.type)
 end
+------------------------------------------------------------------------------
+testing"fnmatch"
+assert(ox.fnmatch("test", "test"))
+assert(ox.fnmatch("tes*", "test"))
+assert(ox.fnmatch("tes*", "tes"))
+assert(ox.fnmatch("tes*", "test2"))
+assert(ox.fnmatch("tes?", "test"))
+assert(ox.fnmatch("tes?", "tes") == false)
+assert(ox.fnmatch("tes?", "test2") == false)
+assert(ox.fnmatch("*test", "/test", ox.FNM_PATHNAME) == false)
+assert(ox.fnmatch("*test", ".test", ox.FNM_PERIOD) == false)
 
 ------------------------------------------------------------------------------
 testing"glob"


### PR DESCRIPTION
Hello Reuben,

Despite Lua string library patterns supersede it, the standard filename matching utility may be very useful for some applications. I, for example, have a case where I match a user-supplied filename or pattern and I don't want to expose the complexities of string.match to the user.
