### PR TITLE
Use AC_SEARCH_LIBS instead of AC_CHECK_LIBS in configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -74,13 +74,12 @@ gl_INIT
 dnl Check for header files
 AC_HEADER_STDC
 
+dnl Search libs
+AC_SEARCH_LIBS(crypt, crypt)
+
 dnl Check for functions
 AC_CHECK_FUNCS([strlcpy])
 AC_CHECK_FUNCS([crypt])
-if test $ac_cv_func_crypt = no; then
-  # crypt is not in the default libraries, try libcrypt.  FIXME: anywhere else?
-  AC_CHECK_LIB([crypt], [crypt], [LIBS="$LIBS -lcrypt"])
-fi
 
 dnl Compiler flags for POSIX
 dnl Get this from autotools/gnulib


### PR DESCRIPTION
Search libcrypt before checking function crypt to fix function crypt not found when configuring.
