### PR TITLE
fix Lua5.2 compatible for lcurses.

### DIFF
--- a/curses.lua
+++ b/curses.lua
@@ -1,13 +1,12 @@
 --- Lua bindings for curses
-module ("curses", package.seeall)
-
-require "curses_c"
+local M = require "curses_c"
+local curses = M
 
 -- These Lua functions detect number of args, like Unified Funcs in Perl Curses
 -- see http://pjb.com.au/comp/lua/lcurses.html
 -- see http://search.cpan.org/perldoc?Curses
 
-function addch (...)
+function M.addch (...)
   if #{...} == 3 then
     return curses.stdscr():mvaddch(...)
   else
@@ -15,7 +14,7 @@ function addch (...)
   end
 end
 
-function addstr(...) -- detect number of args, like Unified Funcs in Perl Curses
+function M.addstr(...) -- detect number of args, like Unified Funcs in Perl Curses
   if #{...} == 3 then
     return curses.stdscr():mvaddstr(...)
   else
@@ -23,12 +22,12 @@ function addstr(...) -- detect number of args, like Unified Funcs in Perl Curses
   end
 end
 
-function attrset (a) return curses.stdscr():attrset(a) end
-function clear ()    return curses.stdscr():clear() end
-function clrtobot () return curses.stdscr():clrtobot() end
-function clrtoeol () return curses.stdscr():clrtoeol() end
+function M.attrset (a) return curses.stdscr():attrset(a) end
+function M.clear ()    return curses.stdscr():clear() end
+function M.clrtobot () return curses.stdscr():clrtobot() end
+function M.clrtoeol () return curses.stdscr():clrtoeol() end
 
-function getch (...)
+function M.getch (...)
   local c
   if #{...} == 2 then
     c = curses.stdscr():mvgetch(...)
@@ -42,17 +41,19 @@ function getch (...)
   return c
 end
 
-function getstr (...)
+function M.getstr (...)
   if #{...} > 1 then
     return curses.stdscr():mvgetstr(...)
   else
     return curses.stdscr():getstr(...)
   end
 end
-getnstr = getstr
+M.getnstr = getstr
 
-function getyx ()    return curses.stdscr():getyx() end
-function keypad (b)  return curses.stdscr():keypad(b) end
-function move (y,x)  return curses.stdscr():move(y,x) end
-function refresh ()  return curses.stdscr():refresh() end
-function timeout (t) return curses.stdscr():timeout(t) end
+function M.getyx ()    return curses.stdscr():getyx() end
+function M.keypad (b)  return curses.stdscr():keypad(b) end
+function M.move (y,x)  return curses.stdscr():move(y,x) end
+function M.refresh ()  return curses.stdscr():refresh() end
+function M.timeout (t) return curses.stdscr():timeout(t) end
+
+return M

--- a/lcurses.c
+++ b/lcurses.c
@@ -2052,7 +2052,7 @@ static const luaL_reg curseslib[] =
 
 
 /* Prototype to keep compiler happy. */
-int luaopen_curses_c (lua_State *L);
+LUALIB_API int luaopen_curses_c (lua_State *L);
 
 int luaopen_curses_c (lua_State *L)
 {

--- a/lua52compat.h
+++ b/lua52compat.h
@@ -5,7 +5,11 @@
 */
 
 #if LUA_VERSION_NUM == 502
+#define luaL_reg luaL_Reg
 #define lua_objlen lua_rawlen
+#define lua_strlen lua_rawlen
+#define luaL_openlib(L,n,l,nup) luaL_setfuncs((L),(l),(nup))
+#define luaL_register(L,n,l) luaL_newlib((L),(l))
 
 #include <assert.h>
 static int luaL_typerror(lua_State *L, int narg, const char *tname)


### PR DESCRIPTION
I had build only lcurses with pdcurses on Windows, and found that something broken Lua 5.2, some as lua_strlen (changed to lua_rawlen), and luaL_register (changed to luaL_newlib), and I modified curses.lua to compatible with 5.2's module system.
