### PR TITLE
crypt: this function is available on darwin, but no crypt.h header is

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -74,14 +74,14 @@ gl_INIT
 
 dnl Check for header files
 AC_HEADER_STDC
-AC_CHECK_HEADERS([crypt.h])
+AC_CHECK_HEADERS([crypt.h sys/statvfs.h])
 
 dnl Search libs
 AC_SEARCH_LIBS([crypt], [crypt],
   [AC_DEFINE([HAVE_CRYPT], [], [Define this if your system has a crypt() function])])
 
 dnl Check for functions
-AC_CHECK_FUNCS([strlcpy])
+AC_CHECK_FUNCS([strlcpy statvfs])
 
 dnl Compiler flags for POSIX
 dnl Get this from autotools/gnulib

--- a/lposix.c
+++ b/lposix.c
@@ -41,7 +41,7 @@
 #if HAVE_CRYPT_H
 #  include <crypt.h>
 #endif
-#if _POSIX_VERSION >= 200112L
+#if HAVE_SYS_STATVFS_H
 #  include <sys/statvfs.h>
 #endif
 
@@ -1499,7 +1499,7 @@ static int Pstat(lua_State *L)			/** stat(path,[options]) */
 	return doselection(L, 2, Sstat, Fstat, &s);
 }
 
-#if _POSIX_VERSION >= 200112L
+#if defined (HAVE_STATVFS)
 static void Fstatvfs(lua_State *L, int i, const void *data)
 {
 	const struct statvfs *s=data;
@@ -2349,6 +2349,8 @@ static const luaL_Reg R[] =
 	MENTRY( Psyslog		),
 	MENTRY( Pcloselog	),
 	MENTRY( Psetlogmask	),
+#endif
+#if defined (HAVE_STATVFS)
 	MENTRY( Pstatvfs	),
 #endif
 #undef MENTRY


### PR DESCRIPTION
One of the main principles of Autoconf is that you should test for
features, not for versions - exactly because of compilation problems
like this, where Apple sets _POSIX_VERSION to make us think that
crypt.h is available, but there is no crypt.h header.
- configure.ac (crypt.h): Test for presence of this header.
  (crypt): If the crypt function is available, whether or not the
  additional -lcrypt library is required, define HAVE_CRYPT.
- lposix.c (crypt.h): Include it if configure found it.
  (Pcrypt): Define it if configure detected a system crypt API.
  (R): List Pcrypt, if we defined it earlier.
