### PR TITLE
Update Github URL.

### DIFF
--- a/ChangeLog.old
+++ b/ChangeLog.old
@@ -1,5 +1,5 @@
 History is now tracked in git.
-https://github.com/rrthomas/luaposix
+https://github.com/luaposix/luaposix
 
 2008-07-18 Natanael Copa <natanael.copa _AT_ gmail.com>
   * fix rpoll to ignore the POLLHUP and POLLNVAL reported at:

--- a/luaposix.rockspec.in
+++ b/luaposix.rockspec.in
@@ -1,7 +1,7 @@
 package="@PACKAGE@"
 version="@VERSION@-1"
 source = {
-  url = "https://github.com/downloads/rrthomas/@PACKAGE@/@PACKAGE@-@VERSION@.tar.gz",
+  url = "https://github.com/downloads/luaposix/@PACKAGE@/@PACKAGE@-@VERSION@.tar.gz",
   md5 = "@MD5@",
   dir = "@PACKAGE@-@VERSION@"
 }
@@ -12,7 +12,7 @@ description = {
       POSIX is the IEEE Portable Operating System Interface standard.
       luaposix is based on lposix and lcurses.
    ]],
-  homepage = "http://github.com/rrthomas/@PACKAGE@/",
+  homepage = "http://github.com/luaposix/@PACKAGE@/",
   license = "MIT/X11"
 }
 dependencies = {

--- a/make_lcurses_doc.pl
+++ b/make_lcurses_doc.pl
@@ -477,8 +477,8 @@ and <code>mvwaddch()</code>.
 <p></p>
 </DIV><h2><a name="author">AUTHOR</a></h2><DIV CLASS="txt">
 <p><B>luaposix curses</B> was originally written by Tiago Dionizio, and is maintained by Reuben Thomas at
-<a href="http://github.com/rrthomas/luaposix">
-http://github.com/rrthomas/luaposix</a><BR>
+<a href="http://github.com/luaposix/luaposix">
+http://github.com/luaposix/luaposix</a><BR>
 This documentation was created by
 <A HREF="make_lcurses_doc">a script</A>
 written by


### PR DESCRIPTION
Replaces references to `rrthomas/luaposix` with `luaposix/luaposix`. In its current state, installation via `luarocks` fails.
