### PR TITLE
configury: use AM_PROG_AR for automake 1.13.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -58,6 +58,9 @@ if test "$gl_gcc_warnings" = yes; then
   gl_WARN_ADD([-fmudflap])
 fi
 
+dnl required by automake 1.12.x, not available in 1.10.x
+m4_ifdef([AM_PROG_AR], [AM_PROG_AR])
+
 LT_PREREQ([2.2.6])
 LT_INIT([disable-static])
 LT_OUTPUT


### PR DESCRIPTION
- configure.ac (AM_PROG_AR): Required by recent automake releases,
  but not available in very old releases.
