### PR TITLE
configury: no need to fork for libtool.m4 variables.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -60,10 +60,7 @@ fi
 
 LT_PREREQ([2.2.6])
 LT_INIT([disable-static])
-LT_OUTPUT
 
-eval `./libtool --config |grep '^objdir='`
-eval `./libtool --config |grep '^shrext_cmds='`
 module=yes eval shrext=$shrext_cmds
 
 AC_SUBST([objdir])


### PR DESCRIPTION
libtool.m4 is expanded into configure already, so the values are
available after LT_INIT in configure.in without creating config.lt
to copy the values we already have into an early libtool script,
and then fork again to grep the content of those copies back into
configure!!  (LT_OUTPUT is only necessary if you need to run
configure time compilation tests using the libtool script to
wrap the actual compiler).
- configure.ac (LT_OUTPUT): Remove.
  (shrext): shrext_cmds is already set by LT_INIT, so just use it
  without calling the early libtool script.
