### PR TITLE
curses: conditional resizeterm support.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -103,6 +103,11 @@ AC_ARG_VAR(CURSES_LIB, [linker flags for curses library])
 AC_SUBST(WANTEDLIBS)
 AC_SUBST(WANTEDLUA)
 
+save_LIBS=$LIBS
+LIBS="$CURSES_LIB $LIBS"
+AC_CHECK_FUNCS([resizeterm])
+LIBS=$save_LIBS
+
 dnl Lua 5.1 or 5.2
 AX_PROG_LUA(501, 503)
 AX_LUA_HEADERS

--- a/lcurses.c
+++ b/lcurses.c
@@ -711,6 +711,24 @@ static int Cnapms(lua_State *L)
 
 /*
 ** =======================================================
+** resizeterm
+** =======================================================
+*/
+
+static int Cresizeterm(lua_State *L)
+{
+    int nlines  = luaL_checkint(L, 1);
+    int ncols   = luaL_checkint(L, 2);
+#if HAVE_RESIZETERM
+    lua_pushboolean(L, B(resizeterm (nlines, ncols)));
+    return 1;
+#else
+    return luaL_error (L, "`resizeterm' is not implemented by your curses library");
+#endif
+}
+
+/*
+** =======================================================
 ** beep
 ** =======================================================
 */
@@ -1990,6 +2008,9 @@ static const luaL_Reg curseslib[] =
     MENTRY( Cripoffline	),
     MENTRY( Cnapms	),
     MENTRY( Ccurs_set	),
+
+    /* resize */
+    MENTRY( Cresizeterm	),
 
     /* beep */
     MENTRY( Cbeep	),


### PR DESCRIPTION
- configure.ac (AC_CHECK_FUNCS): Check whether resizeterm is
  implemented by the selected curses library.
- lcurses.c (Cresizeterm): If it is, use it, otherwise throw an
  error to explain why not.
  (curseslib): Add it to the toplevel curses functions.
