### PR TITLE
configury: handle missing ldoc binary.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -25,8 +25,6 @@ LUA_PATH ?= ;
 LUA_CPATH ?= ;
 LUA_ENV = LUA_PATH="$(abs_srcdir)/?.lua;$(LUA_PATH)" LUA_CPATH="$(abs_builddir)/$(objdir)/?$(shrext);$(LUA_CPATH)"
 
-HTML = curses.html lcurses_c.html
-
 LUATESTS =				\
 	$(srcdir)/tests-posix.lua	\
 	$(srcdir)/tests-curses.lua
@@ -37,7 +35,8 @@ LUNITTESTS=				\
 ROCKSPEC = $(PACKAGE)-$(VERSION)-1.rockspec
 
 dist_doc_DATA = 			\
-	$(HTML)				\
+	curses.html			\
+	lcurses_c.html			\
 	docs/index.html			\
 	docs/ldoc.css
 examplesdir = $(docdir)/examples
@@ -53,11 +52,15 @@ EXTRA_DIST =				\
 
 DISTCLEANFILES = $(PACKAGE).rockspec
 
-$(HTML): lcurses.c make_lcurses_doc.pl
+$(dist_doc_DATA): lcurses.c make_lcurses_doc.pl
 	$(PERL) make_lcurses_doc.pl
+if HAVE_LDOC
+	$(LDOC) .
+else
+	touch docs/index.html docs/ldoc.css
+endif
 
-doc: $(HTML)
-	ldoc .
+doc: $(dist_doc_DATA)
 
 check-local:
 	ls $(LUATESTS) | $(LUA_ENV) xargs -L 1 $(LUA)

--- a/configure.ac
+++ b/configure.ac
@@ -124,6 +124,10 @@ fi
 dnl md5sum
 AX_WITH_PROG([MD5SUM], [md5sum], [false])
 
+dnl ldoc
+AX_WITH_PROG([LDOC], [ldoc], [false])
+AM_CONDITIONAL([HAVE_LDOC], [test false != "$LDOC"])
+
 dnl Generate output files
 AC_CONFIG_MACRO_DIR(m4)
 AC_CONFIG_HEADER(config.h)


### PR DESCRIPTION
- configure.ac (LDOC): Set with AX_WITH_PROG.
  (HAVE_LDOC): New conditional.
- Makefile.am (HTML): Fold into...
  (dist_doc_DATA): ...here.
  Run ldoc when available, otherwise touch the requried files to
  prevent build failure.
