### PR TITLE
gnulib: no need to link always empty libgnu.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,7 +1,5 @@
 ## Process this file with automake to produce Makefile.in
 
-SUBDIRS = lib
-
 ACLOCAL_AMFLAGS = -I m4
 
 AM_CPPFLAGS = $(LUA_INCLUDE)
@@ -13,7 +11,7 @@ dist_data_DATA = posix.lua $(WANTEDLUA)
 
 posix_c_la_SOURCES = lposix.c
 posix_c_la_CFLAGS = $(POSIX_EXTRA_CFLAGS)
-posix_c_la_LDFLAGS = -module -avoid-version $(builddir)/lib/libgnu.la $(POSIX_EXTRA_LDFLAGS)
+posix_c_la_LDFLAGS = -module -avoid-version $(POSIX_EXTRA_LDFLAGS)
 
 curses_c_la_SOURCES = lcurses.c
 curses_c_la_LDFLAGS = -module -avoid-version $(CURSES_LIB) -rpath '$(libdir)'

--- a/bootstrap.conf
+++ b/bootstrap.conf
@@ -13,6 +13,7 @@
 # Additional gnulib-tool options to use.
 gnulib_tool_options='
         --no-changelog
+	--avoid=dummy
 '
 
 # gnulib modules used by this package.
@@ -82,15 +83,25 @@ luaposix_force_changelog ()
 func_add_hook func_gnulib_tool luaposix_force_changelog
 
 
+# luaposix_remove_empty_lib
+# -------------------------
+# No need to maintain the always empty lib subdir.
+luaposix_remove_empty_lib ()
+{
+    $debug_cmd
+
+    rm -rf lib
+}
+func_add_hook func_gnulib_tool luaposix_remove_empty_lib
+
+
 # luaposix_finish
 # ----------------------
 # Configure script does not require ChangeLog.
-# Copy dummy.c with correct license.
 luaposix_finish ()
 {
     $debug_cmd
 
-    cp -fp ./dummy.c $source_base/
     rm ChangeLog || exit 1
 }
 func_add_hook func_fini luaposix_finish

--- a/configure.ac
+++ b/configure.ac
@@ -131,5 +131,5 @@ AM_CONDITIONAL([HAVE_LDOC], [test false != "$LDOC"])
 dnl Generate output files
 AC_CONFIG_MACRO_DIR(m4)
 AC_CONFIG_HEADER(config.h)
-AC_CONFIG_FILES([Makefile lib/Makefile] m4_defn([AC_PACKAGE_TARNAME])[.rockspec luarocks-config.lua])
+AC_CONFIG_FILES([Makefile ]m4_defn([AC_PACKAGE_TARNAME])[.rockspec luarocks-config.lua])
 AC_OUTPUT


### PR DESCRIPTION
Now that we have no C modules from gnulib, there's no need to
build and link the always empty library any more.
- Makefile.am (SUBDIRS): Remove.
- configure.ac (AC_CONFIG_FILES): Remove lib/Makefile.
- bootstrap.conf (gnulib_tool_options): Add --avoid=dummy to skip
  the one remaining empty gnulib C source file.
  (luaposix_remove_empty_lib): gnulib-tool now generates a useless
  lib subdirectory containing just a Makefile.am and .gitignore. We
  don't use or need it any more, so delete it.
  (luaposix_finish): Don't copy dummy.c out of gnulib.
