### PR TITLE
poll only returns active events in revents table, increases performance

### DIFF
--- a/lposix.c
+++ b/lposix.c
@@ -1062,7 +1062,7 @@ static void Ppoll_events_to_table(lua_State *L, int table, short events)
 	for (i = 0; i < PPOLL_EVENT_NUM; i++)
 	{
 		if(events & Ppoll_event_map[i].bit) {
-			lua_pushboolean(L, events & Ppoll_event_map[i].bit);
+			lua_pushboolean(L, 1);
 			lua_setfield(L, table, Ppoll_event_map[i].name);
 		}
 	}


### PR DESCRIPTION
The current poll implementation always adds a boolean for each possible event (IN, OUT, HUP, PRI, ERR, NVAL) to the fd's revents table, setting them to true or false. This patch only sets the triggered events to true, and leaves out the others.

Increases performance in my test case with approx 20%.
