### PR TITLE
Fix poll example, open failed due to wrong 2nd argument type

### DIFF
--- a/examples/poll.lua
+++ b/examples/poll.lua
@@ -1,7 +1,7 @@
 local P = require 'posix'
 
-local fd1 = P.open(arg[1],{'RDONLY'})
-local fd2 = P.open(arg[2],{'RDONLY'})
+local fd1 = P.open(arg[1], P.O_RDONLY)
+local fd2 = P.open(arg[2], P.O_RDONLY)
 
 local fds = {
   [fd1] = { events = {IN=true} },


### PR DESCRIPTION
examples/poll.lua is broken.

2nd argument type changed from {'RDONLY'} to P.O_RDONLY
