### PR TITLE
I broke poll with commit 8deb0ebd041ab6d4761f86a7a906dd850111bae7

### DIFF
--- a/lposix.c
+++ b/lposix.c
@@ -1071,10 +1071,8 @@ static void Ppoll_events_to_table(lua_State *L, int table, short events)
 
 	for (i = 0; i < PPOLL_EVENT_NUM; i++)
 	{
-		if(events & Ppoll_event_map[i].bit) {
-			lua_pushboolean(L, 1);
-			lua_setfield(L, table, Ppoll_event_map[i].name);
-		}
+		lua_pushboolean(L, events & Ppoll_event_map[i].bit);
+		lua_setfield(L, table, Ppoll_event_map[i].name);
 	}
 }
 


### PR DESCRIPTION
Earlier commit changed poll() to only set active events in the revents table for performance reasons.

The result is just fine for calling poll() only once, but breaks things for subsequent calls to poll() when passing the same table again. In this case, the inactive events are not cleared from the revents table, causing false positives. This patch reverts to the original behavior. 

(I did some performance tests with setting the inactive events to nil instead of false, but the difference is hardly noticable)
