### PR TITLE
Fixed glob example

### DIFF
--- a/examples/glob.lua
+++ b/examples/glob.lua
@@ -1,8 +1,5 @@
-require "posix"
+local posix = require "posix"
 
 for i, j in pairs (posix.glob ("/proc/[0-9]*/exe")) do
-  local f = posix.readlink (j)
-  if f then
-    print (f)
-  end
+  print(j)
 end


### PR DESCRIPTION
Added missing 'posix ='. Also removed readlink() because /proc on linux violates posix and does not properly fill in st_size on lstat(), causing readlink() to fail with EINVAL.
