### PR TITLE
Fix and clean up Markdown formatting in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,29 +1,26 @@
 luaposix
 ========
 
-by the [luaposix project][github]
-
-[github]: https://github.com/luaposix/luaposix
+By the [luaposix project][GitHub]
 
 [![travis-ci status](https://secure.travis-ci.org/luaposix/luaposix.png?branche=master)](http://travis-ci.org/luaposix/luaposix/builds)
 
-luaposix is a POSIX binding, including curses, for Lua 5.1 and 5.2;
+luaposix is a POSIX binding, including curses, for [Lua] 5.1 and 5.2;
 like most libraries it simply binds to C APIs on the underlying
-system, so it won't work on a non-POSIX system. However, it does try
+system, so it won't work on non-POSIX systems. However, it does try
 to detect the level of POSIX conformance of the underlying system and
 bind only available APIs.
 
-luaposix is released under the MIT license, like Lua (see COPYING;
+luaposix is released under the MIT license, like Lua (see [COPYING];
 it's basically the same as the BSD license). There is no warranty.
 
 Please report bugs and make suggestions by opening an issue on the
 github tracker.
 
-
 Installation
 ------------
 
-The simplest way to install luaposix is with [LuaRocks][]. To install the
+The simplest way to install luaposix is with [LuaRocks]. To install the
 latest release (recommended):
 
     luarocks install luaposix
@@ -36,57 +33,38 @@ With Lua 5.1, luaposix requires the bitop library from http://bitop.luajit.org/
 (On Lua 5.2 it will work whether bitop is installed or not.)
 
 To install without LuaRocks, check out the sources from the
-[repository][github], and then run the following commands: the
-dependencies are listed in the dependencies entry of the file
+[repository][GitHub] and run the following commands:
+
+    cd luaposix
+    ./bootstrap
+    ./configure --prefix=INSTALLATION-ROOT-DIRECTORY
+    make all check install
+
+Dependencies are listed in the dependencies entry of the file
 `rockspec.conf`. You will also need Autoconf and Automake.
 
-  cd luaposix
-  ./bootstrap
-  ./configure --prefix=INSTALLATION-ROOT-DIRECTORY
-  make all check install
-
-See [INSTALL][] for instructions for `configure`, and `configure --help`
+See [INSTALL] for `configure` instructions and `configure --help`
 for details of available command-line switches.
-
-[luarocks]: http://www.luarocksporg "LuaRocks Project"
-[install]: https://raw.github.com/luaposix/luaposix/release/INSTALL
-
 
 Use
 ---
 
 The library is split into two modules. The basic POSIX APIs are in
-"posix"; the curses APIs in "curses".
+`posix` and the curses APIs in `curses`.
 
-There is HTML documentation; to obtain it, run:
+HTML documentation can be generated with [LDoc] by running `make doc`
+or viewed online at <http://luaposix.github.com/luaposix/>.
 
-  make doc
-
-The posix module documentation requires LDoc, from
-
-  https://github.com/stevedonovan/LDoc
-
-It includes links to online man pages. All the HTML documentation is
-online at:
-
-  http://luaposix.github.com/luaposix/
-
-You can find an authoritative online POSIX reference at:
-
-  http://www.opengroup.org/onlinepubs/007904875/toc.htm
-
+The authoritative online POSIX reference is at
+<http://www.opengroup.org/onlinepubs/007904875/toc.htm>.
 
 Example code
 ------------
 
-See the example program tree.lua, along with the tests in
+See the example program `tree.lua`, along with the tests in
 `tests-*.lua`.
 
-For a complete application, see the lua branch of GNU Zile's (a
-cut-down Emacs clone) git repository at:
-
-    http://git.savannah.gnu.org/cgit/zile.git/log/?h=lua
-
+For a complete application, see the lua branch of [GNU Zile].
 
 Bugs reports & patches
 ----------------------
@@ -110,3 +88,12 @@ bear in mind the following points when writing new code:
 3. Thin wrappers: although some existing code contradicts this, wrap
    POSIX APIs in the simplest way possible. If necessary, more
    convenient wrappers can be added in Lua (posix.lua).
+
+
+[Lua]: http://www.lua.org/
+[GitHub]: https://github.com/luaposix/luaposix
+[LuaRocks]: http://www.luarocksporg "Lua package manager"
+[LDoc]: https://github.com/stevedonovan/LDoc "Lua documentation generator"
+[COPYING]: https://raw.github.com/luaposix/luaposix/release/COPYING
+[INSTALL]: https://raw.github.com/luaposix/luaposix/release/INSTALL
+[GNU Zile]: http://git.savannah.gnu.org/cgit/zile.git/log/?h=lua "A cut-down Emacs clone"


### PR DESCRIPTION
- Fix code blocks (2 space indent isn't enough for Markdown)
- Move reference links to end of file (to avoid interrupting reading flow)
- Add a few code spans and links
- Use sentences instead of bullet points where possible

For comparison:
- https://github.com/luaposix/luaposix/blob/master/README.md
- https://github.com/craigbarnes/luaposix/blob/master/README.md
