### PR TITLE
fix without IPv6

### DIFF
--- a/ext/posix/posix.c
+++ b/ext/posix/posix.c
@@ -3637,6 +3637,7 @@ static int Psetsockopt(lua_State *L)
 					break;
 			}
 			break;
+#if defined(IPV6_JOIN_GROUP) && defined(IPV6_LEAVE_GROUP)
 		case IPPROTO_IPV6:
 			switch(optname) {
 				case IPV6_JOIN_GROUP:
@@ -3650,6 +3651,7 @@ static int Psetsockopt(lua_State *L)
 					break;
 			}
 			break;
+#endif
 		case IPPROTO_TCP:
 			switch(optname) {
 				default:
@@ -4697,13 +4699,27 @@ LUALIB_API int luaopen_posix_c (lua_State *L)
 	MENTRY( AI_V4MAPPED	);
 	MENTRY( AI_ALL		);
 	MENTRY( AI_ADDRCONFIG	);
+#endif
 
+#ifdef IPV6_JOIN_GROUP
 	MENTRY( IPV6_JOIN_GROUP		);
+#endif
+#ifdef IPV6_LEAVE_GROUP
 	MENTRY( IPV6_LEAVE_GROUP	);
+#endif
+#ifdef IPV6_MULTICAST_HOPS
 	MENTRY( IPV6_MULTICAST_HOPS	);
+#endif
+#ifdef IPV6_MULTICAST_IF
 	MENTRY( IPV6_MULTICAST_IF	);
+#endif
+#ifdef IPV6_MULTICAST_LOOP
 	MENTRY( IPV6_MULTICAST_LOOP	);
+#endif
+#ifdef IPV6_UNICAST_HOPS
 	MENTRY( IPV6_UNICAST_HOPS	);
+#endif
+#ifdef IPV6_V6ONLY
 	MENTRY( IPV6_V6ONLY		);
 #endif
 #undef MENTRY


### PR DESCRIPTION
I work with [Buildroot](http://buildroot.net/) which is a tool for building embedded linux system.
Buildroot supports various C libraries which have or not the IPv6 support.

With uClibc without IPv6, I obtain the following error :

```
  CC       ext/posix/ext_posix_posix_c_la-posix.lo
ext/posix/posix.c: In function 'Psetsockopt':
ext/posix/posix.c:3642:10: error: 'IPV6_JOIN_GROUP' undeclared (first use in this function)
ext/posix/posix.c:3642:10: note: each undeclared identifier is reported only once for each function it appears in
ext/posix/posix.c:3643:10: error: 'IPV6_LEAVE_GROUP' undeclared (first use in this function)
ext/posix/posix.c: In function 'luaopen_posix_c':
ext/posix/posix.c:4701:2: error: 'IPV6_JOIN_GROUP' undeclared (first use in this function)
ext/posix/posix.c:4702:2: error: 'IPV6_LEAVE_GROUP' undeclared (first use in this function)
ext/posix/posix.c:4703:2: error: 'IPV6_MULTICAST_HOPS' undeclared (first use in this function)
ext/posix/posix.c:4704:2: error: 'IPV6_MULTICAST_IF' undeclared (first use in this function)
ext/posix/posix.c:4705:2: error: 'IPV6_MULTICAST_LOOP' undeclared (first use in this function)
ext/posix/posix.c:4706:2: error: 'IPV6_UNICAST_HOPS' undeclared (first use in this function)
ext/posix/posix.c:4707:2: error: 'IPV6_V6ONLY' undeclared (first use in this function)
```
