### PR TITLE
Fix a typo: gettimeofday uses microsec, not nano.

### DIFF
--- a/ext/posix/posix.c
+++ b/ext/posix/posix.c
@@ -4481,7 +4481,7 @@ Get time of day.
 @function gettimeofday
 @see gettimeofday(2)
 @return epoch table: contains fields "sec" (the number of seconds elapsed
- since the epoch), and "usec" (remainder in nanoseconds)
+ since the epoch), and "usec" (remainder in microseconds)
 */
 static int
 Pgettimeofday(lua_State *L)


### PR DESCRIPTION
I hope this isn't too small a fix.
