### PR TITLE
Fix compilation and runtime on QNX based systems

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -86,11 +86,12 @@ gl_INIT
 
 dnl Compiler flags for POSIX.2001 or better compliance.
 case $host_os in
-  darwin*|openbsd*)
+  *nto* | *qnx* | darwin* | openbsd* )
     # Setting _XOPEN_SOURCE here messes up header declarations
     ;;
   *)
     AC_SUBST([POSIX_EXTRA_CPPFLAGS], [-D_XOPEN_SOURCE=700])
+    AC_DEFINE([HAVE_SYSV_MSG_QUEUES], [], [Define this if your system has the SysV message queue interface])
     ;;
 esac
 
@@ -118,6 +119,13 @@ AC_CHECK_LIB([rt], [clock_gettime])
 AC_SUBST([LIBRT], [$LIBS])
 LIBS=$save_LIBS
 
+dnl Socket (required for qnx)
+save_LIBS=$LIBS
+LIBS=
+AC_SEARCH_LIBS([socket], [socket], [])
+AC_SUBST([LIBSOCKET], [$LIBS])
+LIBS=$save_LIBS
+
 dnl Curses
 AX_WITH_CURSES
 AC_ARG_VAR(CURSES_LIB, [linker flags for curses library])
@@ -128,7 +136,7 @@ AC_CHECK_FUNCS([resizeterm])
 LIBS=$save_LIBS
 
 dnl Check for functions
-AC_CHECK_FUNCS([strlcpy statvfs posix_fadvise sched_getsheduler sched_setscheduler])
+AC_CHECK_FUNCS([strlcpy statvfs posix_fadvise sched_getsheduler sched_setscheduler mkdtemp mkstemp gethostid])
 
 AX_PROG_LUA(5.1, 5.4)
 AX_LUA_HEADERS

--- a/ext/posix/curses.c
+++ b/ext/posix/curses.c
@@ -81,10 +81,10 @@
 
 
 #include <config.h>
+#include "_helpers.c"
 
 #if HAVE_CURSES
 
-#include "_helpers.c"
 #include "strlcpy.c"
 
 #include "curses/chstr.c"
@@ -1205,9 +1205,11 @@ Ptigetstr (lua_State *L)
 	return 1;
 }
 
+#endif
 
 static const luaL_Reg curseslib[] =
 {
+#if HAVE_CURSES
 	LPOSIX_FUNC( Pbaudrate		),
 	LPOSIX_FUNC( Pbeep		),
 	LPOSIX_FUNC( Pcbreak		),
@@ -1263,9 +1265,9 @@ static const luaL_Reg curseslib[] =
 	LPOSIX_FUNC( Punctrl		),
 	LPOSIX_FUNC( Pungetch		),
 	LPOSIX_FUNC( Puse_default_colors),
+#endif
 	{NULL, NULL}
 };
-#endif
 
 /***
 Constants.

--- a/ext/posix/stdlib.c
+++ b/ext/posix/stdlib.c
@@ -100,6 +100,7 @@ Pgrantpt(lua_State *L)
 	return pushresult(L, grantpt(fd), "grantpt");
 }
 
+#if HAVE_MKDTEMP
 
 /***
 Create a unique temporary directory.
@@ -133,6 +134,8 @@ Pmkdtemp(lua_State *L)
 	return (r == NULL) ? pusherror(L, path) : 1;
 }
 
+#endif
+#if HAVE_MKSTEMP
 
 /***
 Create a unique temporary file.
@@ -173,6 +176,7 @@ Pmkstemp(lua_State *L)
 	return (r == -1) ? pusherror(L, path) : 2;
 }
 
+#endif
 
 /***
 Open a pseudoterminal.
@@ -304,8 +308,12 @@ static const luaL_Reg posix_stdlib_fns[] =
 	LPOSIX_FUNC( Pabort		),
 	LPOSIX_FUNC( Pgetenv		),
 	LPOSIX_FUNC( Pgrantpt		),
+#if HAVE_MKDTEMP
 	LPOSIX_FUNC( Pmkdtemp		),
+#endif
+#if HAVE_MKSTEMP
 	LPOSIX_FUNC( Pmkstemp		),
+#endif
 	LPOSIX_FUNC( Popenpt		),
 	LPOSIX_FUNC( Pptsname		),
 	LPOSIX_FUNC( Prealpath		),

--- a/ext/posix/sys/msg.c
+++ b/ext/posix/sys/msg.c
@@ -24,7 +24,7 @@
 
 #include "_helpers.c"	/* For LPOSIX_2001_COMPLIANT */
 
-#if LPOSIX_2001_COMPLIANT
+#if LPOSIX_2001_COMPLIANT && defined(HAVE_SYSV_MSG_QUEUES)
 #include <sys/ipc.h>
 #include <sys/msg.h>
 #include <sys/types.h>
@@ -151,7 +151,7 @@ Pmsgrcv(lua_State *L)
 
 static const luaL_Reg posix_sys_msg_fns[] =
 {
-#if LPOSIX_2001_COMPLIANT
+#if LPOSIX_2001_COMPLIANT && defined(HAVE_SYSV_MSG_QUEUES)
 	LPOSIX_FUNC( Pmsgget		),
 	LPOSIX_FUNC( Pmsgsnd		),
 	LPOSIX_FUNC( Pmsgrcv		),
@@ -191,7 +191,7 @@ luaopen_posix_sys_msg(lua_State *L)
 	lua_pushliteral(L, "posix.sys.msg for " LUA_VERSION " / " PACKAGE_STRING);
 	lua_setfield(L, -2, "version");
 
-#if LPOSIX_2001_COMPLIANT
+#if LPOSIX_2001_COMPLIANT && defined(HAVE_SYSV_MSG_QUEUES)
 	LPOSIX_CONST( IPC_CREAT		);
 	LPOSIX_CONST( IPC_EXCL		);
 	LPOSIX_CONST( IPC_PRIVATE	);

--- a/ext/posix/sys/socket.c
+++ b/ext/posix/sys/socket.c
@@ -611,7 +611,6 @@ Pshutdown(lua_State *L)
 	return pushresult(L, shutdown(fd, how), "shutdown");
 }
 
-
 /***
 Get and set options on sockets.
 @function setsockopt
@@ -885,7 +884,9 @@ luaopen_posix_sys_socket(lua_State *L)
 
 	LPOSIX_CONST( TCP_NODELAY	);
 
+# ifdef AI_ADDRCONFIG
 	LPOSIX_CONST( AI_ADDRCONFIG	);
+# endif
 # ifdef AI_ALL
 	LPOSIX_CONST( AI_ALL		);
 # endif

--- a/ext/posix/unistd.c
+++ b/ext/posix/unistd.c
@@ -593,6 +593,7 @@ Pgetuid(lua_State *L)
 	return pushintresult(getuid ());
 }
 
+#if HAVE_GETHOSTID
 
 /***
 Get host id.
@@ -607,6 +608,7 @@ Pgethostid(lua_State *L)
 	return pushintresult(gethostid());
 }
 
+#endif
 
 /***
 Test whether a file descriptor refers to a terminal.
@@ -1041,7 +1043,9 @@ static const luaL_Reg posix_unistd_fns[] =
 	LPOSIX_FUNC( Pgetpid		),
 	LPOSIX_FUNC( Pgetppid		),
 	LPOSIX_FUNC( Pgetuid		),
+#if HAVE_GETHOSTID
 	LPOSIX_FUNC( Pgethostid		),
+#endif
 	LPOSIX_FUNC( Pisatty		),
 	LPOSIX_FUNC( Plink		),
 	LPOSIX_FUNC( Plseek		),

--- a/local.mk
+++ b/local.mk
@@ -111,7 +111,7 @@ EXTRA_ext_posix_posix_la_SOURCES =	\
 	ext/posix/utime.c		\
 	$(NOTHING_ELSE)
 
-ext_posix_posix_la_LDFLAGS = $(AM_LDFLAGS) $(LIBCRYPT) $(LIBRT) $(CURSES_LIB)
+ext_posix_posix_la_LDFLAGS = $(AM_LDFLAGS) $(LIBCRYPT) $(LIBSOCKET) $(LIBRT) $(CURSES_LIB)
 
 luaexecposixdir = $(luaexecdir)/posix
 luaexecposixsysdir = $(luaexecposixdir)/sys


### PR DESCRIPTION
The latest release of luaposix makes use of several APIs that are simply not present on the QNX platform. More annoyingly, the SysV message passing API is present in QNX's headers, but not in their runtime C library. This patch makes necessary changes to autoconf and to the implementation files to allow luaposix to load and run as expected on a QNX platform.
