### PR TITLE
Fix compilation and runtime on QNX based systems

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -125,6 +125,13 @@ AC_CHECK_LIB([rt], [clock_gettime])
 AC_SUBST([LIBRT], [$LIBS])
 LIBS=$save_LIBS
 
+dnl Socket (required for qnx)
+save_LIBS=$LIBS
+LIBS=
+AC_SEARCH_LIBS([socket], [socket], [])
+AC_SUBST([LIBSOCKET], [$LIBS])
+LIBS=$save_LIBS
+
 dnl Curses
 AX_WITH_CURSES
 AC_ARG_VAR(CURSES_LIB, [linker flags for curses library])

--- a/ext/include/_helpers.c
+++ b/ext/include/_helpers.c
@@ -43,6 +43,11 @@
 #  define LPOSIX_2001_COMPLIANT 1
 #endif
 
+#ifndef __QNX__
+#  define HAS_SYSV_MSG_QUEUES LPOSIX_2001_COMPLIANT
+#endif
+
+
 #include "lua.h"
 #include "lualib.h"
 #include "lauxlib.h"

--- a/ext/posix/sys/msg.c
+++ b/ext/posix/sys/msg.c
@@ -24,7 +24,7 @@
 
 #include "_helpers.c"	/* For LPOSIX_2001_COMPLIANT */
 
-#if LPOSIX_2001_COMPLIANT
+#if HAVE_SYSV_MSG_QUEUES
 #include <sys/ipc.h>
 #include <sys/msg.h>
 #include <sys/types.h>
@@ -151,7 +151,7 @@ Pmsgrcv(lua_State *L)
 
 static const luaL_Reg posix_sys_msg_fns[] =
 {
-#if LPOSIX_2001_COMPLIANT
+#if HAVE_SYSV_MSG_QUEUES
 	LPOSIX_FUNC( Pmsgget		),
 	LPOSIX_FUNC( Pmsgsnd		),
 	LPOSIX_FUNC( Pmsgrcv		),
@@ -191,7 +191,7 @@ luaopen_posix_sys_msg(lua_State *L)
 	lua_pushliteral(L, "posix.sys.msg for " LUA_VERSION " / " PACKAGE_STRING);
 	lua_setfield(L, -2, "version");
 
-#if LPOSIX_2001_COMPLIANT
+#if HAVE_SYSV_MSG_QUEUES
 	LPOSIX_CONST( IPC_CREAT		);
 	LPOSIX_CONST( IPC_EXCL		);
 	LPOSIX_CONST( IPC_PRIVATE	);

--- a/ext/posix/unistd.c
+++ b/ext/posix/unistd.c
@@ -593,6 +593,7 @@ Pgetuid(lua_State *L)
 	return pushintresult(getuid ());
 }
 
+#if HAVE_GETHOSTID
 
 /***
 Get host id.
@@ -615,6 +616,7 @@ Pgethostid(lua_State *L)
 #endif
 }
 
+#endif
 
 /***
 Test whether a file descriptor refers to a terminal.
@@ -1049,7 +1051,9 @@ static const luaL_Reg posix_unistd_fns[] =
 	LPOSIX_FUNC( Pgetpid		),
 	LPOSIX_FUNC( Pgetppid		),
 	LPOSIX_FUNC( Pgetuid		),
+#if HAVE_GETHOSTID
 	LPOSIX_FUNC( Pgethostid		),
+#endif
 	LPOSIX_FUNC( Pisatty		),
 	LPOSIX_FUNC( Plink		),
 	LPOSIX_FUNC( Plseek		),


### PR DESCRIPTION
This is a resubmission of pull request #188.

This version should now disable SysV message queues on QNX while enabling them on all other supported operating systems. It also fixes some minor bugs on systems that do not have ncurses support.

The _nto_ and _qnx_ patterns were taken from auto generated paterns used in the `configure` script.

Specifically: line 6739 in the generated configure script contains the following snippet of a case statement:

``` sh
*nto* | *qnx*)
  lt_cv_deplibs_check_method=pass_all
  ;;
```
