### PR TITLE
Implement mkdtemp on unsupported platforms

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -163,7 +163,7 @@ dnl Statvfs support
 AC_CHECK_FUNCS([statvfs])
 
 dnl Deprecated or otherwise spottily supported POSIX functions
-AC_CHECK_FUNCS([gethostid posix_fadvise])
+AC_CHECK_FUNCS([gethostid mkdtemp posix_fadvise])
 
 
 dnl Lua


### PR DESCRIPTION
mkdtemp() was not officially included in POSIX until POSIX.1 2008. QNX
does not include an implementation of it because it does not support
POSIX.1 2008. And, while many other operating systems implemented this
function in the late '90s. QNX did not follow suit.

Many other projects have found this method useful enough that they have
implemented it internally in order to provide an API for creating
temporary directories. So this patch implements a rough API for
generating temporary directories on the QNX platform.

For reference, I found this discussion about mkdtemp on posix systems.
http://stackoverflow.com/questions/2336242/recursive-mkdir-system-call-on-unix

Also according to the [man page](http://linux.die.net/man/3/mkdtemp) for `mkdtemp` on linux, `mkdtemp` requires `_XOPEN_SOURCE >= 700` which is also not supported by QNX, or `_BSD_SUPPORT` when using glibc. As QNX makes no claims of compliance with `_BSD_SUPPORT` in their libc I am not surprised that they do not support this function, even though everyone else has supported it for over 10 years.

I still think the better option is to simply declare that this method is not available on systems without a certain level of POSIX support (like QNX) and people developing on QNX should make use of the other methods to re-create the function in lua directly all of those methods are available already in lua with the existing lua-posix support.
