### PR TITLE
Workarounds for missing NetBSD curses functions.

### DIFF
--- a/ext/include/_helpers.c
+++ b/ext/include/_helpers.c
@@ -38,6 +38,17 @@
 #include <term.h>
 #endif
 
+
+/* NetBSD's default curses implementation is not quite complete.
+ * This disables the missing functions unless linked to ncurses 
+ * instead. */
+#ifdef __NetBSD__
+# ifndef NCURSES_VERSION
+#   define NETBSD_MISSING_FUNCTIONS
+# endif
+#endif
+
+
 /* Some systems set _POSIX_C_SOURCE over _POSIX_VERSION! */
 #if _POSIX_C_SOURCE >= 200112L || _POSIX_VERSION >= 200112L || _XOPEN_SOURCE >= 600
 # define LPOSIX_2001_COMPLIANT 1
@@ -371,6 +382,16 @@ badoption(lua_State *L, int i, const char *what, int option)
 /* ================== *
  * Utility functions. *
  * ================== */
+
+
+static int
+notimplemented(lua_State *L)
+{
+	lua_pushnil(L);
+	lua_pushstring(L, "Function not implemented - please check libcurses");
+	return 2;
+}
+
 
 
 #define pushintegerfield(k,v) LPOSIX_STMT_BEG {				\

--- a/ext/posix/curses.c
+++ b/ext/posix/curses.c
@@ -626,6 +626,8 @@ ripoffline_cb(WINDOW* w, int cols)
 }
 
 
+#ifndef NETBSD_MISSING_FUNCTIONS
+
 /***
 Reduce the available size of the main screen.
 @function ripoffline
@@ -670,6 +672,8 @@ Pripoffline(lua_State *L)
 	/* and tell curses we are going to take the line */
 	return pushokresult(ripoffline(top_line ? 1 : -1, ripoffline_cb));
 }
+
+#endif /* NETBSD_MISSING_FUNCTIONS */
 
 
 /***
@@ -794,6 +798,8 @@ Pdoupdate(lua_State *L)
 	return pushokresult(doupdate());
 }
 
+
+#ifndef NETBSD_MISSING_FUNCTIONS
 
 /***
 Initialise the soft label keys area.
@@ -957,6 +963,9 @@ Pslk_attrset(lua_State *L)
 	chtype attrs = checkch(L, 1);
 	return pushokresult(slk_attrset(attrs));
 }
+
+
+#endif /* NETBSD_MISSING_FUNCTIONS */
 
 
 /***
@@ -1244,6 +1253,7 @@ static const luaL_Reg curseslib[] =
 	LPOSIX_FUNC( Ppair_content	),
 	LPOSIX_FUNC( Praw		),
 	LPOSIX_FUNC( Presizeterm	),
+#ifndef NETBSD_MISSING_FUNCTIONS
 	LPOSIX_FUNC( Pripoffline	),
 	LPOSIX_FUNC( Pslk_attroff	),
 	LPOSIX_FUNC( Pslk_attron	),
@@ -1256,6 +1266,20 @@ static const luaL_Reg curseslib[] =
 	LPOSIX_FUNC( Pslk_restore	),
 	LPOSIX_FUNC( Pslk_set		),
 	LPOSIX_FUNC( Pslk_touch		),
+#else
+	LPOSIX_STR_1( Pripoffline ), ( notimplemented ),
+	LPOSIX_STR_1( Pslk_attroff ), ( notimplemented ),
+	LPOSIX_STR_1( Pslk_attron ), ( notimplemented ),
+	LPOSIX_STR_1( Pslk_attrset ), ( notimplemented ),
+	LPOSIX_STR_1( Pslk_clear ), ( notimplemented ),
+	LPOSIX_STR_1( Pslk_init ), ( notimplemented ),
+	LPOSIX_STR_1( Pslk_label ), ( notimplemented ),
+	LPOSIX_STR_1( Pslk_noutrefresh ), ( notimplemented ),
+	LPOSIX_STR_1( Pslk_refresh ), ( notimplemented ),
+	LPOSIX_STR_1( Pslk_restore ), ( notimplemented ),
+	LPOSIX_STR_1( Pslk_set ), ( notimplemented ),
+	LPOSIX_STR_1( Pslk_touch ), ( notimplemented ),
+#endif /* NETBSD_MISSING_FUNCTIONS */
 	LPOSIX_FUNC( Pstart_color	),
 	LPOSIX_FUNC( Pstdscr		),
 	LPOSIX_FUNC( Ptermattrs		),

--- a/ext/posix/curses/window.c
+++ b/ext/posix/curses/window.c
@@ -258,6 +258,8 @@ Wsyncup(lua_State *L)
 }
 
 
+#ifndef NETBSD_MISSING_FUNCTIONS
+
 /***
 Automatically mark ancestors of a changed window for refresh.
 @function syncok
@@ -272,6 +274,8 @@ Wsyncok(lua_State *L)
 	int bf = lua_toboolean(L, 2);
 	return pushokresult(syncok(w, bf));
 }
+
+#endif
 
 
 /***
@@ -1113,6 +1117,8 @@ Wscrollok(lua_State *L)
 }
 
 
+#ifndef NETBSD_MISSING_FUNCTIONS
+
 /***
 Automatically call @{refresh} whenever the window content is changed.
 @function immedok
@@ -1128,6 +1134,8 @@ Wimmedok(lua_State *L)
 	immedok(w, bf);
 	return 0;
 }
+
+#endif
 
 
 /***
@@ -1836,7 +1844,11 @@ static const luaL_Reg posix_curses_window_fns[] =
 	LPOSIX_FUNC( Whline		),
 	LPOSIX_FUNC( Widcok		),
 	LPOSIX_FUNC( Widlok		),
+#ifndef NETBSD_MISSING_FUNCTIONS
 	LPOSIX_FUNC( Wimmedok		),
+#else
+	LPOSIX_STR_1( Wimmedok ), ( notimplemented ),
+#endif
 	LPOSIX_FUNC( Winsertln		),
 	LPOSIX_FUNC( Wintrflush		),
 	LPOSIX_FUNC( Wis_linetouched	),
@@ -1880,7 +1892,11 @@ static const luaL_Reg posix_curses_window_fns[] =
 	LPOSIX_FUNC( Wsub		),
 	LPOSIX_FUNC( Wsubpad		),
 	LPOSIX_FUNC( Wsyncdown		),
+#ifndef NETBSD_MISSING_FUNCTIONS
 	LPOSIX_FUNC( Wsyncok		),
+#else
+	LPOSIX_STR_1( Wsyncok ), ( notimplemented ),
+#endif
 	LPOSIX_FUNC( Wsyncup		),
 	LPOSIX_FUNC( Wtimeout		),
 	LPOSIX_FUNC( Wtouch		),


### PR DESCRIPTION
Fix for issue #199, "Luaposix fails to load on NetBSD".