### PR TITLE
Popen

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: c
 env:
   global:
     - _COMPILE="libtool --mode=compile --tag=CC gcc"
-    - _CFLAGS="-O2 -Wall -DLUA_COMPAT_ALL -DLUA_USE_LINUX"
+    - _CFLAGS="-O2 -Wall -DLUA_COMPAT_ALL -DLUA_COMPAT_5_2 -DLUA_USE_LINUX"
     - _INSTALL="libtool --mode=install install -p"
     - _LINK="libtool --mode=link --tag=CC gcc"
     - _LIBS="-lm -Wl,-E -ldl -lreadline"

--- a/ext/include/compat-5.2.c
+++ b/ext/include/compat-5.2.c
@@ -1,0 +1,683 @@
+#include <errno.h>
+#include <string.h>
+
+#include "lua.h"
+#include "lauxlib.h"
+#include "compat-5.2.h"
+
+#if !defined(LUA_VERSION_NUM) || LUA_VERSION_NUM == 501
+
+int lua_absindex (lua_State *L, int i) {
+  if (i < 0 && i > LUA_REGISTRYINDEX)
+    i += lua_gettop(L) + 1;
+  return i;
+}
+
+
+void lua_copy (lua_State *L, int from, int to) {
+  int abs_to = lua_absindex(L, to);
+  luaL_checkstack(L, 1, "not enough stack slots");
+  lua_pushvalue(L, from);
+  lua_replace(L, abs_to);
+}
+
+
+void lua_rawgetp (lua_State *L, int i, const void *p) {
+  int abs_i = lua_absindex(L, i);
+  lua_pushlightuserdata(L, (void*)p);
+  lua_rawget(L, abs_i);
+}
+
+void lua_rawsetp (lua_State *L, int i, const void *p) {
+  int abs_i = lua_absindex(L, i);
+  luaL_checkstack(L, 1, "not enough stack slots");
+  lua_pushlightuserdata(L, (void*)p);
+  lua_insert(L, -2);
+  lua_rawset(L, abs_i);
+}
+
+
+void *luaL_testudata (lua_State *L, int i, const char *tname) {
+  void *p = lua_touserdata(L, i);
+  luaL_checkstack(L, 2, "not enough stack slots");
+  if (p == NULL || !lua_getmetatable(L, i))
+    return NULL;
+  else {
+    int res = 0;
+    luaL_getmetatable(L, tname);
+    res = lua_rawequal(L, -1, -2);
+    lua_pop(L, 2);
+    if (!res)
+      p = NULL;
+  }
+  return p;
+}
+
+
+lua_Number lua_tonumberx (lua_State *L, int i, int *isnum) {
+  lua_Number n = lua_tonumber(L, i);
+  if (isnum != NULL) {
+    *isnum = (n != 0 || lua_isnumber(L, i));
+  }
+  return n;
+}
+
+
+#define PACKAGE_KEY "_COMPAT52_PACKAGE"
+
+static void push_package_table (lua_State *L) {
+  lua_pushliteral(L, PACKAGE_KEY);
+  lua_rawget(L, LUA_REGISTRYINDEX);
+  if (!lua_istable(L, -1)) {
+    lua_pop(L, 1);
+    /* try to get package table from globals */
+    lua_pushliteral(L, "package");
+    lua_rawget(L, LUA_GLOBALSINDEX);
+    if (lua_istable(L, -1)) {
+      lua_pushliteral(L, PACKAGE_KEY);
+      lua_pushvalue(L, -2);
+      lua_rawset(L, LUA_REGISTRYINDEX);
+    }
+  }
+}
+
+void lua_getuservalue (lua_State *L, int i) {
+  luaL_checktype(L, i, LUA_TUSERDATA);
+  luaL_checkstack(L, 2, "not enough stack slots");
+  lua_getfenv(L, i);
+  lua_pushvalue(L, LUA_GLOBALSINDEX);
+  if (lua_rawequal(L, -1, -2)) {
+    lua_pop(L, 1);
+    lua_pushnil(L);
+    lua_replace(L, -2);
+  } else {
+    lua_pop(L, 1);
+    push_package_table(L);
+    if (lua_rawequal(L, -1, -2)) {
+      lua_pop(L, 1);
+      lua_pushnil(L);
+      lua_replace(L, -2);
+    } else
+      lua_pop(L, 1);
+  }
+}
+
+void lua_setuservalue (lua_State *L, int i) {
+  luaL_checktype(L, i, LUA_TUSERDATA);
+  if (lua_isnil(L, -1)) {
+    luaL_checkstack(L, 1, "not enough stack slots");
+    lua_pushvalue(L, LUA_GLOBALSINDEX);
+    lua_replace(L, -2);
+  }
+  lua_setfenv(L, i);
+}
+
+
+/*
+** Adapted from Lua 5.2.0
+*/
+void luaL_setfuncs (lua_State *L, const luaL_Reg *l, int nup) {
+  luaL_checkstack(L, nup+1, "too many upvalues");
+  for (; l->name != NULL; l++) {  /* fill the table with given functions */
+    int i;
+    lua_pushstring(L, l->name);
+    for (i = 0; i < nup; i++)  /* copy upvalues to the top */
+      lua_pushvalue(L, -(nup + 1));
+    lua_pushcclosure(L, l->func, nup);  /* closure with those upvalues */
+    lua_settable(L, -(nup + 3)); /* table must be below the upvalues, the name and the closure */
+  }
+  lua_pop(L, nup);  /* remove upvalues */
+}
+
+
+void luaL_setmetatable (lua_State *L, const char *tname) {
+  luaL_checkstack(L, 1, "not enough stack slots");
+  luaL_getmetatable(L, tname);
+  lua_setmetatable(L, -2);
+}
+
+
+int luaL_getsubtable (lua_State *L, int i, const char *name) {
+  int abs_i = lua_absindex(L, i);
+  luaL_checkstack(L, 3, "not enough stack slots");
+  lua_pushstring(L, name);
+  lua_gettable(L, abs_i);
+  if (lua_istable(L, -1))
+    return 1;
+  lua_pop(L, 1);
+  lua_newtable(L);
+  lua_pushstring(L, name);
+  lua_pushvalue(L, -2);
+  lua_settable(L, abs_i);
+  return 0;
+}
+
+
+#if !defined(COMPAT52_IS_LUAJIT)
+static int countlevels (lua_State *L) {
+  lua_Debug ar;
+  int li = 1, le = 1;
+  /* find an upper bound */
+  while (lua_getstack(L, le, &ar)) { li = le; le *= 2; }
+  /* do a binary search */
+  while (li < le) {
+    int m = (li + le)/2;
+    if (lua_getstack(L, m, &ar)) li = m + 1;
+    else le = m;
+  }
+  return le - 1;
+}
+
+static int findfield (lua_State *L, int objidx, int level) {
+  if (level == 0 || !lua_istable(L, -1))
+    return 0;  /* not found */
+  lua_pushnil(L);  /* start 'next' loop */
+  while (lua_next(L, -2)) {  /* for each pair in table */
+    if (lua_type(L, -2) == LUA_TSTRING) {  /* ignore non-string keys */
+      if (lua_rawequal(L, objidx, -1)) {  /* found object? */
+        lua_pop(L, 1);  /* remove value (but keep name) */
+        return 1;
+      }
+      else if (findfield(L, objidx, level - 1)) {  /* try recursively */
+        lua_remove(L, -2);  /* remove table (but keep name) */
+        lua_pushliteral(L, ".");
+        lua_insert(L, -2);  /* place '.' between the two names */
+        lua_concat(L, 3);
+        return 1;
+      }
+    }
+    lua_pop(L, 1);  /* remove value */
+  }
+  return 0;  /* not found */
+}
+
+static int pushglobalfuncname (lua_State *L, lua_Debug *ar) {
+  int top = lua_gettop(L);
+  lua_getinfo(L, "f", ar);  /* push function */
+  lua_pushvalue(L, LUA_GLOBALSINDEX);
+  if (findfield(L, top + 1, 2)) {
+    lua_copy(L, -1, top + 1);  /* move name to proper place */
+    lua_pop(L, 2);  /* remove pushed values */
+    return 1;
+  }
+  else {
+    lua_settop(L, top);  /* remove function and global table */
+    return 0;
+  }
+}
+
+static void pushfuncname (lua_State *L, lua_Debug *ar) {
+  if (*ar->namewhat != '\0')  /* is there a name? */
+    lua_pushfstring(L, "function " LUA_QS, ar->name);
+  else if (*ar->what == 'm')  /* main? */
+      lua_pushliteral(L, "main chunk");
+  else if (*ar->what == 'C') {
+    if (pushglobalfuncname(L, ar)) {
+      lua_pushfstring(L, "function " LUA_QS, lua_tostring(L, -1));
+      lua_remove(L, -2);  /* remove name */
+    }
+    else
+      lua_pushliteral(L, "?");
+  }
+  else
+    lua_pushfstring(L, "function <%s:%d>", ar->short_src, ar->linedefined);
+}
+
+#define LEVELS1 12  /* size of the first part of the stack */
+#define LEVELS2 10  /* size of the second part of the stack */
+
+void luaL_traceback (lua_State *L, lua_State *L1,
+                                const char *msg, int level) {
+  lua_Debug ar;
+  int top = lua_gettop(L);
+  int numlevels = countlevels(L1);
+  int mark = (numlevels > LEVELS1 + LEVELS2) ? LEVELS1 : 0;
+  if (msg) lua_pushfstring(L, "%s\n", msg);
+  lua_pushliteral(L, "stack traceback:");
+  while (lua_getstack(L1, level++, &ar)) {
+    if (level == mark) {  /* too many levels? */
+      lua_pushliteral(L, "\n\t...");  /* add a '...' */
+      level = numlevels - LEVELS2;  /* and skip to last ones */
+    }
+    else {
+      lua_getinfo(L1, "Slnt", &ar);
+      lua_pushfstring(L, "\n\t%s:", ar.short_src);
+      if (ar.currentline > 0)
+        lua_pushfstring(L, "%d:", ar.currentline);
+      lua_pushliteral(L, " in ");
+      pushfuncname(L, &ar);
+      lua_concat(L, lua_gettop(L) - top);
+    }
+  }
+  lua_concat(L, lua_gettop(L) - top);
+}
+#endif
+
+
+void luaL_checkversion (lua_State *L) {
+  (void)L;
+}
+
+
+#if !defined(COMPAT52_IS_LUAJIT)
+int luaL_fileresult (lua_State *L, int stat, const char *fname) {
+  int en = errno;  /* calls to Lua API may change this value */
+  if (stat) {
+    lua_pushboolean(L, 1);
+    return 1;
+  }
+  else {
+    lua_pushnil(L);
+    if (fname)
+      lua_pushfstring(L, "%s: %s", fname, strerror(en));
+    else
+      lua_pushstring(L, strerror(en));
+    lua_pushnumber(L, (lua_Number)en);
+    return 3;
+  }
+}
+#endif
+
+
+#endif /* Lua 5.0 or Lua 5.1 */
+
+
+#if defined(LUA_VERSION_NUM) && LUA_VERSION_NUM == 501
+#include <limits.h>
+
+typedef LUAI_INT32 LUA_INT32;
+
+/********************************************************************/
+/*                    extract of 5.2's luaconf.h                    */
+/*  detects proper defines for faster unsigned<->number conversion  */
+/*           see copyright notice at the end of this file           */
+/********************************************************************/
+
+#if !defined(LUA_ANSI) && defined(_WIN32) && !defined(_WIN32_WCE)
+#define LUA_WIN		/* enable goodies for regular Windows platforms */
+#endif
+
+
+#if defined(LUA_NUMBER_DOUBLE) && !defined(LUA_ANSI)	/* { */
+
+/* Microsoft compiler on a Pentium (32 bit) ? */
+#if defined(LUA_WIN) && defined(_MSC_VER) && defined(_M_IX86)	/* { */
+
+#define LUA_MSASMTRICK
+#define LUA_IEEEENDIAN		0
+#define LUA_NANTRICK
+
+/* pentium 32 bits? */
+#elif defined(__i386__) || defined(__i386) || defined(__X86__) /* }{ */
+
+#define LUA_IEEE754TRICK
+#define LUA_IEEELL
+#define LUA_IEEEENDIAN		0
+#define LUA_NANTRICK
+
+/* pentium 64 bits? */
+#elif defined(__x86_64)						/* }{ */
+
+#define LUA_IEEE754TRICK
+#define LUA_IEEEENDIAN		0
+
+#elif defined(__POWERPC__) || defined(__ppc__)			/* }{ */
+
+#define LUA_IEEE754TRICK
+#define LUA_IEEEENDIAN		1
+
+#else								/* }{ */
+
+/* assume IEEE754 and a 32-bit integer type */
+#define LUA_IEEE754TRICK
+
+#endif								/* } */
+
+#endif							/* } */
+
+
+/********************************************************************/
+/*                    extract of 5.2's llimits.h                    */
+/*       gives us lua_number2unsigned and lua_unsigned2number       */
+/*           see copyright notice at the end of this file           */
+/********************************************************************/
+
+#if defined(MS_ASMTRICK) || defined(LUA_MSASMTRICK)	/* { */
+/* trick with Microsoft assembler for X86 */
+
+#define lua_number2unsigned(i,n)  \
+  {__int64 l; __asm {__asm fld n   __asm fistp l} i = (unsigned int)l;}
+
+
+#elif defined(LUA_IEEE754TRICK)		/* }{ */
+/* the next trick should work on any machine using IEEE754 with
+   a 32-bit int type */
+
+union compat52_luai_Cast { double l_d; LUA_INT32 l_p[2]; };
+
+#if !defined(LUA_IEEEENDIAN)	/* { */
+#define LUAI_EXTRAIEEE	\
+  static const union compat52_luai_Cast ieeeendian = {-(33.0 + 6755399441055744.0)};
+#define LUA_IEEEENDIANLOC	(ieeeendian.l_p[1] == 33)
+#else
+#define LUA_IEEEENDIANLOC	LUA_IEEEENDIAN
+#define LUAI_EXTRAIEEE		/* empty */
+#endif				/* } */
+
+#define lua_number2int32(i,n,t) \
+  { LUAI_EXTRAIEEE \
+    volatile union compat52_luai_Cast u; u.l_d = (n) + 6755399441055744.0; \
+    (i) = (t)u.l_p[LUA_IEEEENDIANLOC]; }
+
+#define lua_number2unsigned(i,n)	lua_number2int32(i, n, lua_Unsigned)
+
+#endif				/* } */
+
+
+/* the following definitions always work, but may be slow */
+
+#if !defined(lua_number2unsigned)	/* { */
+/* the following definition assures proper modulo behavior */
+#if defined(LUA_NUMBER_DOUBLE) || defined(LUA_NUMBER_FLOAT)
+#include <math.h>
+#define SUPUNSIGNED	((lua_Number)(~(lua_Unsigned)0) + 1)
+#define lua_number2unsigned(i,n)  \
+	((i)=(lua_Unsigned)((n) - floor((n)/SUPUNSIGNED)*SUPUNSIGNED))
+#else
+#define lua_number2unsigned(i,n)	((i)=(lua_Unsigned)(n))
+#endif
+#endif				/* } */
+
+
+#if !defined(lua_unsigned2number)
+/* on several machines, coercion from unsigned to double is slow,
+   so it may be worth to avoid */
+#define lua_unsigned2number(u)  \
+    (((u) <= (lua_Unsigned)INT_MAX) ? (lua_Number)(int)(u) : (lua_Number)(u))
+#endif
+
+/********************************************************************/
+
+
+static void compat52_call_lua (lua_State *L, char const code[], size_t len,
+                               int nargs, int nret) {
+  lua_rawgetp(L, LUA_REGISTRYINDEX, (void*)code);
+  if (lua_type(L, -1) != LUA_TFUNCTION) {
+    lua_pop(L, 1);
+    if (luaL_loadbuffer(L, code, len, "=none"))
+      lua_error(L);
+    lua_pushvalue(L, -1);
+    lua_rawsetp(L, LUA_REGISTRYINDEX, (void*)code);
+  }
+  lua_insert(L, -nargs-1);
+  lua_call(L, nargs, nret);
+}
+
+static const char compat52_arith_code[] = {
+  'l', 'o', 'c', 'a', 'l', ' ', 'o', 'p', ',', 'a', ',', 'b',
+  '=', '.', '.', '.', '\n',
+  'i', 'f', ' ', 'o', 'p', '=', '=', '0', ' ',
+  't', 'h', 'e', 'n', '\n',
+  'r', 'e', 't', 'u', 'r', 'n', ' ', 'a', '+', 'b', '\n',
+  'e', 'l', 's', 'e', 'i', 'f', ' ', 'o', 'p', '=', '=', '1', ' ',
+  't', 'h', 'e', 'n', '\n',
+  'r', 'e', 't', 'u', 'r', 'n', ' ', 'a', '-', 'b', '\n',
+  'e', 'l', 's', 'e', 'i', 'f', ' ', 'o', 'p', '=', '=', '2', ' ',
+  't', 'h', 'e', 'n', '\n',
+  'r', 'e', 't', 'u', 'r', 'n', ' ', 'a', '*', 'b', '\n',
+  'e', 'l', 's', 'e', 'i', 'f', ' ', 'o', 'p', '=', '=', '3', ' ',
+  't', 'h', 'e', 'n', '\n',
+  'r', 'e', 't', 'u', 'r', 'n', ' ', 'a', '/', 'b', '\n',
+  'e', 'l', 's', 'e', 'i', 'f', ' ', 'o', 'p', '=', '=', '4', ' ',
+  't', 'h', 'e', 'n', '\n',
+  'r', 'e', 't', 'u', 'r', 'n', ' ', 'a', '%', 'b', '\n',
+  'e', 'l', 's', 'e', 'i', 'f', ' ', 'o', 'p', '=', '=', '5', ' ',
+  't', 'h', 'e', 'n', '\n',
+  'r', 'e', 't', 'u', 'r', 'n', ' ', 'a', '^', 'b', '\n',
+  'e', 'l', 's', 'e', 'i', 'f', ' ', 'o', 'p', '=', '=', '6', ' ',
+  't', 'h', 'e', 'n', '\n',
+  'r', 'e', 't', 'u', 'r', 'n', ' ', '-', 'a', '\n',
+  'e', 'n', 'd', '\n', '\0'
+};
+
+void lua_arith (lua_State *L, int op) {
+  if (op < LUA_OPADD && op > LUA_OPUNM)
+    luaL_error(L, "invalid 'op' argument for lua_arith");
+  luaL_checkstack(L, 5, "not enough stack slots");
+  if (op == LUA_OPUNM)
+    lua_pushvalue(L, -1);
+  lua_pushnumber(L, op);
+  lua_insert(L, -3);
+  compat52_call_lua(L, compat52_arith_code,
+                    sizeof(compat52_arith_code)-1, 3, 1);
+}
+
+
+static const char compat52_compare_code[] = {
+  'l', 'o', 'c', 'a', 'l', ' ', 'a', ',', 'b', '=', '.', '.', '.', '\n',
+  'r', 'e', 't', 'u', 'r', 'n', ' ', 'a', '<', '=', 'b', '\n', '\0'
+};
+
+int lua_compare (lua_State *L, int idx1, int idx2, int op) {
+  int result = 0;
+  switch (op) {
+    case LUA_OPEQ:
+      return lua_equal(L, idx1, idx2);
+    case LUA_OPLT:
+      return lua_lessthan(L, idx1, idx2);
+    case LUA_OPLE:
+      luaL_checkstack(L, 5, "not enough stack slots");
+      idx1 = lua_absindex(L, idx1);
+      idx2 = lua_absindex(L, idx2);
+      lua_pushvalue(L, idx1);
+      lua_pushvalue(L, idx2);
+      compat52_call_lua(L, (void*)compat52_compare_code,
+                        sizeof(compat52_compare_code)-1, 2, 1);
+      result = lua_toboolean(L, -1);
+      lua_pop(L, 1);
+      return result;
+    default:
+      luaL_error(L, "invalid 'op' argument for lua_compare");
+  }
+  return 0;
+}
+
+
+void lua_pushunsigned (lua_State *L, lua_Unsigned n) {
+  lua_pushnumber(L, lua_unsigned2number(n));
+}
+
+
+lua_Unsigned luaL_checkunsigned (lua_State *L, int i) {
+  lua_Unsigned result;
+  lua_Number n = lua_tonumber(L, i);
+  if (n == 0 && !lua_isnumber(L, i))
+    luaL_checktype(L, i, LUA_TNUMBER);
+  lua_number2unsigned(result, n);
+  return result;
+}
+
+
+lua_Unsigned lua_tounsignedx (lua_State *L, int i, int *isnum) {
+  lua_Unsigned result;
+  lua_Number n = lua_tonumberx(L, i, isnum);
+  lua_number2unsigned(result, n);
+  return result;
+}
+
+
+lua_Unsigned luaL_optunsigned (lua_State *L, int i, lua_Unsigned def) {
+  return luaL_opt(L, luaL_checkunsigned, i, def);
+}
+
+
+lua_Integer lua_tointegerx (lua_State *L, int i, int *isnum) {
+  lua_Integer n = lua_tointeger(L, i);
+  if (isnum != NULL) {
+    *isnum = (n != 0 || lua_isnumber(L, i));
+  }
+  return n;
+}
+
+
+void lua_len (lua_State *L, int i) {
+  switch (lua_type(L, i)) {
+    case LUA_TSTRING: /* fall through */
+    case LUA_TTABLE:
+      if (!luaL_callmeta(L, i, "__len"))
+        lua_pushnumber(L, (int)lua_objlen(L, i));
+      break;
+    case LUA_TUSERDATA:
+      if (luaL_callmeta(L, i, "__len"))
+        break;
+      /* maybe fall through */
+    default:
+      luaL_error(L, "attempt to get length of a %s value",
+                 lua_typename(L, lua_type(L, i)));
+  }
+}
+
+
+int luaL_len (lua_State *L, int i) {
+  int res = 0, isnum = 0;
+  luaL_checkstack(L, 1, "not enough stack slots");
+  lua_len(L, i);
+  res = (int)lua_tointegerx(L, -1, &isnum);
+  lua_pop(L, 1);
+  if (!isnum)
+    luaL_error(L, "object length is not a number");
+  return res;
+}
+
+
+const char *luaL_tolstring (lua_State *L, int idx, size_t *len) {
+  if (!luaL_callmeta(L, idx, "__tostring")) {
+    int t = lua_type(L, idx);
+    switch (t) {
+      case LUA_TNIL:
+        lua_pushliteral(L, "nil");
+        break;
+      case LUA_TSTRING:
+      case LUA_TNUMBER:
+        lua_pushvalue(L, idx);
+        break;
+      case LUA_TBOOLEAN:
+        if (lua_toboolean(L, idx))
+          lua_pushliteral(L, "true");
+        else
+          lua_pushliteral(L, "false");
+        break;
+      default:
+        lua_pushfstring(L, "%s: %p", lua_typename(L, t),
+                                     lua_topointer(L, idx));
+        break;
+    }
+  }
+  return lua_tolstring(L, -1, len);
+}
+
+
+void luaL_requiref (lua_State *L, char const* modname,
+                    lua_CFunction openf, int glb) {
+  luaL_checkstack(L, 3, "not enough stack slots");
+  lua_pushcfunction(L, openf);
+  lua_pushstring(L, modname);
+  lua_call(L, 1, 1);
+  lua_getglobal(L, "package");
+  lua_getfield(L, -1, "loaded");
+  lua_replace(L, -2);
+  lua_pushvalue(L, -2);
+  lua_setfield(L, -2, modname);
+  lua_pop(L, 1);
+  if (glb) {
+    lua_pushvalue(L, -1);
+    lua_setglobal(L, modname);
+  }
+}
+
+
+void luaL_buffinit (lua_State *L, luaL_Buffer_52 *B) {
+  /* make it crash if used via pointer to a 5.1-style luaL_Buffer */
+  B->b.p = NULL;
+  B->b.L = NULL;
+  B->b.lvl = 0;
+  /* reuse the buffer from the 5.1-style luaL_Buffer though! */
+  B->ptr = B->b.buffer;
+  B->capacity = LUAL_BUFFERSIZE;
+  B->nelems = 0;
+  B->L2 = L;
+}
+
+
+char *luaL_prepbuffsize (luaL_Buffer_52 *B, size_t s) {
+  if (B->capacity - B->nelems < s) { /* needs to grow */
+    char* newptr = NULL;
+    size_t newcap = B->capacity * 2;
+    if (newcap - B->nelems < s)
+      newcap = B->nelems + s;
+    if (newcap < B->capacity) /* overflow */
+      luaL_error(B->L2, "buffer too large");
+    newptr = lua_newuserdata(B->L2, newcap);
+    memcpy(newptr, B->ptr, B->nelems);
+    if (B->ptr != B->b.buffer)
+      lua_replace(B->L2, -2); /* remove old buffer */
+    B->ptr = newptr;
+    B->capacity = newcap;
+  }
+  return B->ptr+B->nelems;
+}
+
+
+void luaL_addlstring (luaL_Buffer_52 *B, const char *s, size_t l) {
+  memcpy(luaL_prepbuffsize(B, l), s, l);
+  luaL_addsize(B, l);
+}
+
+
+void luaL_addvalue (luaL_Buffer_52 *B) {
+  size_t len = 0;
+  const char *s = lua_tolstring(B->L2, -1, &len);
+  if (!s)
+    luaL_error(B->L2, "cannot convert value to string");
+  if (B->ptr != B->b.buffer)
+    lua_insert(B->L2, -2); /* userdata buffer must be at stack top */
+  luaL_addlstring(B, s, len);
+  lua_remove(B->L2, B->ptr != B->b.buffer ? -2 : -1);
+}
+
+
+void luaL_pushresult (luaL_Buffer_52 *B) {
+  lua_pushlstring(B->L2, B->ptr, B->nelems);
+  if (B->ptr != B->b.buffer)
+    lua_replace(B->L2, -2); /* remove userdata buffer */
+}
+
+
+#endif /* LUA_VERSION_NUM == 501 */
+
+
+/*********************************************************************
+* This file contains parts of Lua 5.2's source code:
+*
+* Copyright (C) 1994-2013 Lua.org, PUC-Rio.
+*
+* Permission is hereby granted, free of charge, to any person obtaining
+* a copy of this software and associated documentation files (the
+* "Software"), to deal in the Software without restriction, including
+* without limitation the rights to use, copy, modify, merge, publish,
+* distribute, sublicense, and/or sell copies of the Software, and to
+* permit persons to whom the Software is furnished to do so, subject to
+* the following conditions:
+*
+* The above copyright notice and this permission notice shall be
+* included in all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*********************************************************************/
+

--- a/ext/include/compat-5.2.h
+++ b/ext/include/compat-5.2.h
@@ -1,0 +1,169 @@
+#include <stddef.h>
+#include <string.h>
+#include <stdio.h>
+#include "lua.h"
+#include "lauxlib.h"
+#include "lualib.h"
+
+#if !defined(LUA_VERSION_NUM)
+/* Lua 5.0 */
+
+#define LUA_QL(x) "'" x "'"
+#define LUA_QS LUA_QL("%s")
+
+#define luaL_Reg luaL_reg
+
+#define luaL_opt(L, f, n, d) \
+  (lua_isnoneornil(L, n) ? (d) : f(L, n))
+
+#define luaL_addchar(B,c) \
+  ((void)((B)->p < ((B)->buffer+LUAL_BUFFERSIZE) || luaL_prepbuffer(B)), \
+   (*(B)->p++ = (char)(c)))
+
+#endif /* Lua 5.0 */
+
+
+#if defined(LUA_VERSION_NUM) && LUA_VERSION_NUM == 501
+/* Lua 5.1 */
+
+/* PUC-Rio Lua uses lconfig_h as include guard for luaconf.h,
+ * LuaJIT uses luaconf_h. If you use PUC-Rio's include files
+ * but LuaJIT's library, you will need to define the macro
+ * COMPAT52_IS_LUAJIT yourself! */
+#if !defined(COMPAT52_IS_LUAJIT) && defined(luaconf_h)
+#define COMPAT52_IS_LUAJIT
+#endif
+
+/* LuaJIT doesn't define these unofficial macros ... */
+#if !defined(LUAI_INT32)
+#include <limits.h>
+#if INT_MAX-20 < 32760
+#define LUAI_INT32  long
+#define LUAI_UINT32 unsigned long
+#elif INT_MAX > 2147483640L
+#define LUAI_INT32  int
+#define LUAI_UINT32 unsigned int
+#else
+#error "could not detect suitable lua_Unsigned datatype"
+#endif
+#endif
+
+#define LUA_OPADD 0
+#define LUA_OPSUB 1
+#define LUA_OPMUL 2
+#define LUA_OPDIV 3
+#define LUA_OPMOD 4
+#define LUA_OPPOW 5
+#define LUA_OPUNM 6
+#define LUA_OPEQ 0
+#define LUA_OPLT 1
+#define LUA_OPLE 2
+
+typedef LUAI_UINT32 lua_Unsigned;
+
+typedef struct luaL_Buffer_52 {
+  luaL_Buffer b; /* make incorrect code crash! */
+  char *ptr;
+  size_t nelems;
+  size_t capacity;
+  lua_State *L2;
+} luaL_Buffer_52;
+#define luaL_Buffer luaL_Buffer_52
+
+typedef struct luaL_Stream {
+  FILE *f;
+  /* The following field is for LuaJIT which adds a uint32_t field
+   * to file handles. */
+  lua_Unsigned type;
+  lua_CFunction closef;
+} luaL_Stream;
+
+
+#define lua_tounsigned(L, i) lua_tounsignedx(L, i, NULL)
+
+#define lua_rawlen(L, i) lua_objlen(L, i)
+
+void lua_arith (lua_State *L, int op);
+int lua_compare (lua_State *L, int idx1, int idx2, int op);
+void lua_pushunsigned (lua_State *L, lua_Unsigned n);
+lua_Unsigned luaL_checkunsigned (lua_State *L, int i);
+lua_Unsigned lua_tounsignedx (lua_State *L, int i, int *isnum);
+lua_Unsigned luaL_optunsigned (lua_State *L, int i, lua_Unsigned def);
+lua_Integer lua_tointegerx (lua_State *L, int i, int *isnum);
+void lua_len (lua_State *L, int i);
+int luaL_len (lua_State *L, int i);
+const char *luaL_tolstring (lua_State *L, int idx, size_t *len);
+void luaL_requiref (lua_State *L, char const* modname, lua_CFunction openf, int glb);
+
+#define luaL_buffinit luaL_buffinit_52
+void luaL_buffinit (lua_State *L, luaL_Buffer_52 *B);
+
+#define luaL_prepbuffsize luaL_prepbuffsize_52
+char *luaL_prepbuffsize (luaL_Buffer_52 *B, size_t s);
+
+#define luaL_addlstring luaL_addlstring_52
+void luaL_addlstring (luaL_Buffer_52 *B, const char *s, size_t l);
+
+#define luaL_addvalue luaL_addvalue_52
+void luaL_addvalue (luaL_Buffer_52 *B);
+
+#define luaL_pushresult luaL_pushresult_52
+void luaL_pushresult (luaL_Buffer_52 *B);
+
+#undef luaL_buffinitsize
+#define luaL_buffinitsize(L, B, s) \
+  (luaL_buffinit(L, B), luaL_prepbuffsize(B, s))
+
+#undef luaL_prepbuffer
+#define luaL_prepbuffer(B) \
+  luaL_prepbuffsize(B, LUAL_BUFFERSIZE)
+
+#undef luaL_addchar
+#define luaL_addchar(B, c) \
+  ((void)((B)->nelems < (B)->capacity || luaL_prepbuffsize(B, 1)), \
+   ((B)->ptr[(B)->nelems++] = (c)))
+
+#undef luaL_addsize
+#define luaL_addsize(B, s) \
+  ((B)->nelems += (s))
+
+#undef luaL_addstring
+#define luaL_addstring(B, s) \
+  luaL_addlstring(B, s, strlen(s))
+
+#undef luaL_pushresultsize
+#define luaL_pushresultsize(B, s) \
+  (luaL_addsize(B, s), luaL_pushresult(B))
+
+#endif /* Lua 5.1 */
+
+
+#if !defined(LUA_VERSION_NUM) || LUA_VERSION_NUM == 501
+/* Lua 5.0 *or* 5.1 */
+
+#define LUA_OK 0
+
+#define lua_pushglobaltable(L) \
+  lua_pushvalue(L, LUA_GLOBALSINDEX)
+
+#define luaL_newlib(L, l) \
+  (lua_newtable((L)),luaL_setfuncs((L), (l), 0))
+
+void luaL_checkversion (lua_State *L);
+
+#endif /* Lua 5.0 *or* 5.1 */
+
+int lua_absindex (lua_State *L, int i);
+void lua_copy (lua_State *L, int from, int to);
+void lua_rawgetp (lua_State *L, int i, const void *p);
+void lua_rawsetp (lua_State *L, int i, const void *p);
+void *luaL_testudata (lua_State *L, int i, const char *tname);
+lua_Number lua_tonumberx (lua_State *L, int i, int *isnum);
+void lua_getuservalue (lua_State *L, int i);
+void lua_setuservalue (lua_State *L, int i);
+void luaL_setfuncs (lua_State *L, const luaL_Reg *l, int nup);
+void luaL_setmetatable (lua_State *L, const char *tname);
+int luaL_getsubtable (lua_State *L, int i, const char *name);
+void luaL_traceback (lua_State *L, lua_State *L1, const char *msg, int level);
+int luaL_fileresult (lua_State *L, int stat, const char *fname);
+

--- a/ext/posix/stdio.c
+++ b/ext/posix/stdio.c
@@ -21,6 +21,9 @@
 
 #include "_helpers.c"
 
+#if defined(LUA_VERSION_NUM) && LUA_VERSION_NUM == 501
+#include "compat-5.2.c"
+#endif
 
 /***
 Name of controlling terminal.
@@ -57,10 +60,53 @@ Pfileno(lua_State *L)
 }
 
 
+/* This helper function is adapted from Lua 5.3's liolib.c */
+static int
+stdio_fclose (lua_State *L) {
+	luaL_Stream *p = ((luaL_Stream *)luaL_checkudata(L, 1, LUA_FILEHANDLE));
+	int res = fclose(p->f);
+	return luaL_fileresult(L, (res == 0), NULL);
+}
+
+/* This function could be used more generally; see */
+static int
+pushfile (lua_State *L, int fd, const char *mode) {
+	luaL_Stream *p = (luaL_Stream *)lua_newuserdata(L, sizeof(luaL_Stream));
+	luaL_getmetatable(L, LUA_FILEHANDLE);
+	lua_setmetatable(L, -2);
+	p->closef = stdio_fclose;
+	p->f = fdopen(fd, mode);
+	return p->f != NULL;
+}
+
+/***
+Create a Lua file object from a file descriptor.
+@function fdopen
+@tparam int fd file descriptor
+@treturn[1] file file Lua file object *fd*, if successful
+@return[2] nil
+@treturn[2] string error message
+@treturn[2] int errnum
+@usage
+stdout = P.fdopen (posix.STDOUT_FILENO)
+*/
+static int
+Pfdopen(lua_State *L)	/** fdopen(fd, mode) */
+{
+	int fd = checkint(L, 1);
+	const char *mode = luaL_checkstring(L, 2);
+	checknargs(L, 2);
+	if (!pushfile(L, fd, mode))
+		return pusherror(L, "fdopen");
+	return 1;
+}
+
+
 static const luaL_Reg posix_stdio_fns[] =
 {
 	LPOSIX_FUNC( Pctermid		),
 	LPOSIX_FUNC( Pfileno		),
+	LPOSIX_FUNC( Pfdopen		),
 	{NULL, NULL}
 };
 

--- a/lib/posix.lua.in
+++ b/lib/posix.lua.in
@@ -1,7 +1,7 @@
 --[[
  POSIX library for Lua 5.1, 5.2 & 5.3.
  (c) Gary V. Vaughan <gary@vaughan.pe>, 2013-2015
- (c) Reuben Thomas <rrt@sc3d.org> 2010-2013
+ (c) Reuben Thomas <rrt@sc3d.org> 2010-2015
  (c) Natanael Copa <natanael.copa@gmail.com> 2008-2010
 ]]
 --[[--
@@ -195,38 +195,70 @@ else
 end
 
 
---- Run a command or function in a sub-process.
--- @function spawn
+--- Exec a command or Lua function.
+-- @function execx
+-- @fixme deprecate string argument
 -- @param task, a string to be executed as a shell command, or a
 --   table of arguments to `P.execp` or a Lua function, which should read
 --   from standard input, write to standard output, and return an exit code
 -- @tparam string ... positional arguments to the program or function
--- @treturn[1] int status exit code, if successful
--- @treturn[1] string exit type, if wait succeeds
--- @treturn[2] nil
--- @treturn[2] string error message
+-- @treturn nil on error (normally does not return)
+-- @treturn string error message
 
 local unpack = table.unpack or unpack -- 5.3 compatibility
 
-local _exit, errno, execp, fork, wait =
-  M._exit, M.errno, M.execp, M.fork, M.wait
+local errno, execp, _exit =
+  M.errno, M.execp, M._exit
+
+function execx (task, ...)
+  if type (task) == "string" then
+    task = {"/bin/sh", "-c", task, ...}
+  end
+  if type (task) == "table" then
+    execp (unpack (task))
+    -- Only get here if there's an error; kill the fork
+    local _, n = errno ()
+    _exit (n)
+  else
+    _exit (task (...) or 0)
+  end
+end
+
+if _DEBUG ~= false then
+  M.execx = function (task, ...)
+    local argt, typetask = {task, ...}, type (task)
+    if typetask ~= "string" and typetask ~= "table" and typetask ~= "function" then
+      argtypeerror ("execx", 1, "string, table or function", task)
+    end
+    for i = 2, #argt do
+      if type (argt[i]) ~= "string" and type (argt[i]) ~= "nil" then
+	argtypeerror ("execx", i, "string or nil", argt[i])
+      end
+    end
+    return execx (task, ...)
+  end
+else
+  M.execx = execx
+end
+
+
+--- Run a command or function in a sub-process using `P.execx`.
+-- @function spawn
+-- @param task, as for `P.execx`.
+-- @tparam string ... as for `P.execx`
+-- @return values as for `P.wait`
+
+local unpack = table.unpack or unpack -- 5.3 compatibility
+
+local fork, wait =
+  M.fork, M.wait
 
 local function spawn (task, ...)
   local pid, err = fork ()
   if pid == nil then
     return pid, err
   elseif pid == 0 then
-    if type (task) == "string" then
-      task = {"/bin/sh", "-c", task, ...}
-    end
-    if type (task) == "table" then
-      execp (unpack (task))
-      -- Only get here if there's an error; kill the fork
-      local _, no = errno ()
-      _exit (no)
-    else
-      _exit (task (...) or 0)
-    end
+    execx (task, ...)
   else
     local _, reason, status = wait (pid)
     return status, reason -- If wait failed, status is nil & reason is error
@@ -253,7 +285,142 @@ end
 M.system = M.spawn -- OBSOLETE alias
 
 
+local close, dup2, fork, pipe, wait =
+  M.close, M.dup2, M.fork, M.pipe, M.wait
+local STDIN_FILENO, STDOUT_FILENO = M.STDIN_FILENO, M.STDOUT_FILENO
+
+--- Close a pipeline opened with popen or popen_pipeline.
+-- @function pclose
+-- @tparam table pfd pipeline object
+-- @treturn values as for `P.wait`, for the last (or only) stage of the pipeline
+
+local function pclose (pfd)
+  close (pfd.fd)
+  for i = 1, #pfd.pids - 1 do
+    wait (pfd.pids[i])
+  end
+  local _, reason, status = wait (pfd.pids[#pfd.pids])
+  return reason, status
+end
+
+if _DEBUG ~= false then
+  M.pclose = function (...)
+    local argt = {...}
+    checktable ("pclose", 1, argt[1])
+    if #argt > 2 then toomanyargerror ("pclose", 1, #argt) end
+    return pclose (...)
+  end
+else
+  M.pclose = pclose
+end
+
+
+local function move_fd (from_fd, to_fd)
+  if from_fd ~= to_fd then
+    if not dup2 (from_fd, to_fd) then
+      error "error dup2-ing"
+    end
+    close (from_fd)
+  end
+end
+
+--- Run a commands or Lua function in a sub-process.
+-- @function popen
+-- @tparam task, as for @{execx}
+-- @tparam string mode `"r"` for read or `"w"` for write
+-- @func[opt=@{posix.unistd.pipe} pipe_fn function returning a paired read and
+--   write file descriptor
+-- @treturn pfd pipeline object
+
+local function popen (task, mode, pipe_fn)
+  local read_fd, write_fd = (pipe_fn or pipe) ()
+  if not read_fd then
+    error "error opening pipe"
+  end
+  local parent_fd, child_fd, in_fd, out_fd
+  if mode == "r" then
+    parent_fd, child_fd, in_fd, out_fd = read_fd, write_fd, STDIN_FILENO, STDOUT_FILENO
+  elseif mode == "w" then
+    parent_fd, child_fd, in_fd, out_fd = write_fd, read_fd, STDOUT_FILENO, STDIN_FILENO
+  else
+    error "invalid mode"
+  end
+  local pid = fork ()
+  if pid == nil then
+    error "error forking"
+  elseif pid == 0 then -- child process
+    move_fd (child_fd, out_fd)
+    close (parent_fd)
+    _exit (execx (task, child_fd, in_fd, out_fd))
+  end -- parent process
+  close (child_fd)
+  return {pids = {pid}, fd = parent_fd}
+end
+
+if _DEBUG ~= false then
+  M.popen = function (task, ...)
+    local argt, typetask = {task, ...}, type (task)
+    if typetask ~= "string" and typetask ~= "table" and typetask ~= "function" then
+      argtypeerror ("popen", 1, "string, table or function", task)
+    end
+    checkstring ("popen", 2, argt[2])
+    if argt[3] ~= nil and type (argt[3]) ~= "function" then
+      argtypeerror ("popen", 3, "function or nil", argt[3])
+    end
+    if #argt > 3 then toomanyargerror ("popen", 3, #argt) end
+    return popen (task, ...)
+  end
+else
+  M.popen = popen
+end
+
+
 --- Perform a series of commands and Lua functions as a pipeline.
+-- @function popen_pipeline
+-- @tparam table t tasks for @{execx}
+-- @tparam string mode `"r"` for read or `"w"` for write
+-- @func[opt=@{posix.unistd.pipe} pipe_fn function returning a paired read and
+--   write file descriptor
+-- @treturn pfd pipeline object
+
+local function popen_pipeline (tasks, mode, pipe_fn)
+  local first, from, to, inc = 1, 2, #tasks, 1
+  if mode == "w" then
+    first, from, to, inc = #tasks, #tasks - 1, 1, -1
+  end
+  local pfd = popen (tasks[first], mode, pipe_fn)
+  for i = from, to, inc do
+    local pfd_next = popen (function (fd, in_fd, out_fd)
+                              move_fd (pfd.fd, in_fd)
+                              _exit (execx (tasks[i]))
+                            end,
+                            mode,
+                            pipe_fn)
+    close (pfd.fd)
+    pfd.fd = pfd_next.fd
+    table.insert (pfd.pids, pfd_next.pids[1])
+  end
+  return pfd
+end
+
+if _DEBUG ~= false then
+  M.popen_pipeline = function (...)
+    local argt = {...}
+    checktable ("popen_pipeline", 1, argt[1])
+    checkstring ("popen_pipeline", 2, argt[2])
+    if argt[3] ~= nil and type (argt[3]) ~= "function" then
+      argtypeerror ("popen_pipeline", 3, "function or nil", argt[3])
+    end
+    if #argt > 3 then toomanyargerror ("popen_pipeline", 3, #argt) end
+    return popen_pipeline (...)
+  end
+else
+  M.popen_pipeline = popen_pipeline
+end
+
+
+--- Perform a series of commands and Lua functions as a pipeline.
+-- @fixme: deprecate this function
 -- @function pipeline
 -- @tparam table t tasks for @{spawn}
 -- @func[opt=@{posix.unistd.pipe} pipe_fn function returning a paired read and

--- a/specs/posix_spec.yaml
+++ b/specs/posix_spec.yaml
@@ -57,6 +57,7 @@ specify posix:
       badargs.diagnose (f, "pipeline_slurp (table, ?function)")
 
 
+# spawn's tests also cover execx
 - describe spawn:
   - before: f = posix.spawn
 
@@ -64,16 +65,54 @@ specify posix:
       badargs.diagnose (f, "spawn (string|table|function, ?string*)")
 
   - it spawns a command and can detect success:
-      expect (f ("true").to_equal (0))
+      expect (f ("true")).to_equal (0)
   - it can detect failure:
-      expect (f ("false").to_equal (1))
+      expect (f ("false")).to_equal (1)
   - it can pass a table of arguments:
-      expect (f ({"echo", "foo"}).to_equal(0))
+      expect (f ({"echo", "foo"})).to_equal(0)
   - it can pass a function:
       # FIXME: If the function body contains:
       # io.stdout.write ("hello")
       # then the specl results are printed twice; "hello" is not printed
-      expect (f (function () end).to_equal(0))
+      expect (f (function () end)).to_equal(0)
+
+- describe popen:
+  - before:
+      popen, pclose = posix.popen, posix.pclose
+      read, write, BUFSIZE = posix.read, posix.write, posix.BUFSIZ
+  - context with bad arguments:
+      badargs.diagnose (popen, "popen (string|table|function, string, ?function)")
+
+  - it spawns a command and reads its output:
+      p = popen ({"echo", "foo"}, "r")
+      s = posix.read (p.fd, posix.BUFSIZ)
+      pclose (p)
+      expect (s).to_equal "foo\n"
+
+  - it spawns a command and writes its input:
+      p = popen ({"wc"}, "w")
+      s = "foo bar baz"
+      expect (write (p.fd, s)).to_equal (#s)
+      pclose (p)
+
+- describe popen_pipeline:
+  - before:
+      popen_pipeline, pclose = posix.popen_pipeline, posix.pclose
+      read, write, BUFSIZE = posix.read, posix.write, posix.BUFSIZ
+  - context with bad arguments:
+      badargs.diagnose (popen_pipeline, "popen_pipeline (table, string, ?function)")
+
+  - it spawns a pipeline and reads its output:
+      p = popen_pipeline ({{"echo", "foo", "bar", "baz"}, {"wc"}, "wc -l"}, "r")
+      expect (read (p.fd, posix.BUFSIZ)).to_equal ("1\n")
+      pclose (p)
+
+  - it spawns a pipeline and writes its input:
+      s = "foo bar baz"
+      p = popen_pipeline ({{"cat"}, {"wc"}}, "w")
+      expect (write (p.fd, s)).to_equal (#s)
+      pclose (p)
+
 
 - describe timeradd:
   - before:

--- a/specs/posix_stdio_spec.yaml
+++ b/specs/posix_stdio_spec.yaml
@@ -1,0 +1,21 @@
+specify posix.stdio:
+- before:
+    stdio = require "posix.stdio"
+
+
+- describe fdopen:
+    - before:
+        fdopen = stdio.fdopen
+        unistd = require "posix.unistd"
+        STDOUT_FILENO = unistd.STDOUT_FILENO
+        f = fdopen (STDOUT_FILENO, "w")
+
+    - context with bad arguments:
+        badargs.diagnose (fdopen, "(int,string)")
+
+    - it duplicates a stream:
+        expect (type (f)).to_be "userdata"
+
+    - it writes to the duplicated stream:
+        -- Lua 5.1 file.write returns true; > 5.1 returns file handle
+        expect (f:write ("writing to fdopen(stdout)\n")).not_to_be (nil)

--- a/specs/specs.mk
+++ b/specs/specs.mk
@@ -18,6 +18,7 @@ specl_SPECS =						\
 	$(srcdir)/specs/posix_grp_spec.yaml		\
 	$(srcdir)/specs/posix_pwd_spec.yaml		\
 	$(srcdir)/specs/posix_signal_spec.yaml		\
+	$(srcdir)/specs/posix_stdio_spec.yaml		\
 	$(srcdir)/specs/posix_stdlib_spec.yaml		\
 	$(srcdir)/specs/posix_sys_msg_spec.yaml		\
 	$(srcdir)/specs/posix_sys_resource_spec.yaml	\


### PR DESCRIPTION
This pull request adds `popen` and `popen_pipeline` which are based on the existing `pipeline` (and aim to obsolete it), fixing issue #81 (because stdout is no longer redirected in the current process) and reducing the number of processes needed for a pipeline from 2 per command to 1 (because we use the new `execx` directly from the child rather than `spawn`).

This also brings the API closer to the familiar `io.popen`, but with the two key advantages of `pipeline`, namely the process-launching-fu of `spawn` (now moved into `execx`), and the ability to specify a pipe creation function other than `pipe`.

My previous use of `pipeline` now uses `posix.popen` (and doesn't even need a pipeline, because where previously it had an extra process to gather the output of the command, it now reads the command's output directly). I would be happy to remove `pipeline` (the new code is more modular and shorter overall); otherwise we should deprecate it.