### PR TITLE
curses example: use Lua boolean false instead of 0

### DIFF
--- a/examples/curses.lua
+++ b/examples/curses.lua
@@ -10,8 +10,8 @@ local function main ()
   local stdscr = curses.initscr ()
 
   curses.cbreak ()
-  curses.echo (0)	-- not noecho !
-  curses.nl( 0)		-- not nonl !
+  curses.echo (false)	-- not noecho !
+  curses.nl(false)		-- not nonl !
 
   stdscr:clear()
 


### PR DESCRIPTION
`curses.echo(0)` is actually `curses.echo(false)`, because value 0 is truthy in Lua.