### PR TITLE
Add support for alarm(2).

### DIFF
--- a/ext/posix/unistd.c
+++ b/ext/posix/unistd.c
@@ -112,6 +112,21 @@ Paccess(lua_State *L)
 
 
 /***
+Schedule an alarm signal.
+@function alarm
+@int seconds number of seconds to send SIGALRM in
+@return int number of seconds remaining in previous alarm or `0`
+@see alarm(2)
+@usage seconds = P.alarm(10)
+*/
+static int
+Palarm(lua_State *L)
+{
+	int seconds = checkint(L, 1);
+	checknargs(L, 1);
+	return pushintresult(alarm(seconds));
+}
+/***
 Set the working directory.
 @function chdir
 @string path file to act on
@@ -1022,6 +1037,7 @@ static const luaL_Reg posix_unistd_fns[] =
 {
 	LPOSIX_FUNC( P_exit		),
 	LPOSIX_FUNC( Paccess		),
+	LPOSIX_FUNC( Palarm		),
 	LPOSIX_FUNC( Pchdir		),
 	LPOSIX_FUNC( Pchown		),
 	LPOSIX_FUNC( Pclose		),

--- a/specs/posix_unistd_spec.yaml
+++ b/specs/posix_unistd_spec.yaml
@@ -6,6 +6,15 @@ specify posix.unistd:
     -- Assume $USER is the process owner, egid is gid and euid is uid
     ids = pwd.getpwnam (os.getenv "USER")
 
+- describe alarm:
+  - it returns zero when passed zero: |
+      zero = unistd.alarm(0)
+      expect (zero).to_be (0)
+
+  - it can set and reset an alarm: |
+      zero = unistd.alarm(10)
+      ten = unistd.alarm(0)
+      expect (ten>0).to_be (true)
 
 - describe exec:
   - before:


### PR DESCRIPTION
Per issue 225 as promised.  Test is rather basic for make check (just sets/resets the alarm and makes sure the outputs make sense).

Testing so far:

1. make check definitely runs the test and it passes
2. p=require("posix.unistd") p.alarm(2)   definitely sigalrm's the lua interpreter as expected after 2 secs