### PR TITLE
Preserve baud rates in termios table

### DIFF
--- a/ext/posix/termio.c
+++ b/ext/posix/termio.c
@@ -48,11 +48,9 @@ Terminal attributes.
 The constants named below are all available in this submodule's namespace,
 as long as they are supported by the underlying system.
 @table termios
-@int cflag bitwise OR of zero or more of `B0`, `B50`, `B75`, `B110`,
-  `B134`, `B150`, `B200`, `B300`, `B600`, `B1200`, `B1800`, `B2400`,
-  `B4800`, `B9600`, `B19200`, `B38400`, `B57600`, `B115200`, `CSIZE`,
-  `CS5`, `CS6`, `CS7`, `CS8`, `CSTOPB`, `CREAD`, `PARENB`, `PARODD`,
-  `HUPCL`, `CLOCAL` and `CRTSCTS`
+@int cflag bitwise OR of zero or more of
+  `CSIZE`, `CS5`, `CS6`, `CS7`, `CS8`, `CSTOPB`, `CREAD`, `PARENB`,
+  `PARODD`, `HUPCL`, `CLOCAL` and `CRTSCTS`
 @int iflag input flags; bitwise OR of zero or more of `IGNBRK`, `BRKINT`,
   `IGNPAR`, `PARMRK`, `INPCK`, `ISTRIP`, `INLCR`, `IGNCR`, `ICRNL`,
   `IXON`, `IXOFF`, `IXANY`, `IMAXBEL` and `IUTF8`
@@ -62,6 +60,10 @@ as long as they are supported by the underlying system.
   `OXTABS`, `ONOEOT`, `OCRNL`, `ONOCR`, `ONLRET`, `OFILL`, `NLDLY`,
   `TABDLY`, `CRDLY`, `FFDLY`, `BSDLY`, `VTDLY` and `OFDEL`
 @tfield ccs cc array of terminal control characters
+@int ispeed the input baud rate, one of `B0`, `B50`, `B75`, `B110`,
+  `B134`, `B150`, `B200`, `B300`, `B600`, `B1200`, `B1800`, `B2400`,
+  `B4800`, `B9600`, `B19200`, `B38400`, `B57600`, `B115200`,
+@int ospeed the output baud rate (see ispeed for possible values)
 */
 
 
@@ -155,6 +157,8 @@ Ptcgetattr(lua_State *L)
 	pushintegerfield("oflag", t.c_oflag);
 	pushintegerfield("lflag", t.c_lflag);
 	pushintegerfield("cflag", t.c_cflag);
+	pushintegerfield("ispeed",cfgetispeed(&t));
+	pushintegerfield("ospeed",cfgetospeed(&t));
 
 	lua_newtable(L);
 	for (i=0; i<NCCS; i++)
@@ -216,6 +220,8 @@ Ptcsetattr(lua_State *L)
 	lua_getfield(L, 3, "oflag"); t.c_oflag = optint(L, -1, 0); lua_pop(L, 1);
 	lua_getfield(L, 3, "cflag"); t.c_cflag = optint(L, -1, 0); lua_pop(L, 1);
 	lua_getfield(L, 3, "lflag"); t.c_lflag = optint(L, -1, 0); lua_pop(L, 1);
+	lua_getfield(L, 3, "ispeed"); cfsetispeed( &t, optint(L, -1, B0) ); lua_pop(L, 1);
+	lua_getfield(L, 3, "ospeed"); cfsetospeed( &t, optint(L, -1, B0) ); lua_pop(L, 1);
 
 	lua_getfield(L, 3, "cc");
 	for (i=0; i<NCCS; i++)


### PR DESCRIPTION
Previous versions of the termios interface assumed that the baud rate
constants B0 B50 ... B115200 were bit masks that needed to be set in the
cflags member of the termios struct. On most modern operating systems
those are actually mapped to different members (not usually documented)
that contain the baud speed. This speed is set using the posix
functions: cfgetispeed(), cfgetospeed(), cfsetispeed(), and
cfsetospeed(). Because the termios_p struct is translated into a lua
table rather than being maintained in its original data format, extra
information like the baud rate is lost.  This doesn't effect
manipulations on ptty devices, but attempting to use this functionality
over a physical serial connection results in the baud rate being set to
whatever value was in the termios_p when it was created.

This patch fixes this issue by adding the ispeed and ospeed to the lua
representation of termios_p. This will allow luaposix to properly handle
serial files backed by physical pipes.