### PR TITLE
Add support for _SC_PAGESIZE to unistd.sysconf()

### DIFF
--- a/ext/posix/unistd.c
+++ b/ext/posix/unistd.c
@@ -1057,7 +1057,7 @@ Get configuration information at runtime.
 @function sysconf
 @int key one of `_SC_ARG_MAX`, `_SC_CHILD_MAX`, `_SC_CLK_TCK`, `_SC_JOB_CONTROL`,
   `_SC_OPEN_MAX`, `_SC_NGROUPS_MAX`, `_SC_SAVED_IDS`, `_SC_STREAM_MAX`,
-  `_SC_TZNAME_MAX` or `_SC_VERSION`,
+  `_SC_PAGESIZE`, `_SC_TZNAME_MAX` or `_SC_VERSION`,
 @treturn int associated system configuration value
 @see sysconf(3)
 */
@@ -1289,8 +1289,9 @@ luaopen_posix_unistd(lua_State *L)
 	LPOSIX_CONST( _SC_CHILD_MAX	);
 	LPOSIX_CONST( _SC_CLK_TCK	);
 	LPOSIX_CONST( _SC_JOB_CONTROL	);
-	LPOSIX_CONST( _SC_OPEN_MAX	);
 	LPOSIX_CONST( _SC_NGROUPS_MAX	);
+	LPOSIX_CONST( _SC_OPEN_MAX	);
+	LPOSIX_CONST( _SC_PAGESIZE	);
 	LPOSIX_CONST( _SC_SAVED_IDS	);
 	LPOSIX_CONST( _SC_STREAM_MAX	);
 	LPOSIX_CONST( _SC_TZNAME_MAX	);

--- a/lib/posix/deprecated.lua
+++ b/lib/posix/deprecated.lua
@@ -1091,6 +1091,7 @@ local function sysconf (...)
     JOB_CONTROL = _sysconf (unistd._SC_JOB_CONTROL),
     NGROUPS_MAX = _sysconf (unistd._SC_NGROUPS_MAX),
     OPEN_MAX    = _sysconf (unistd._SC_OPEN_MAX),
+    PAGESIZE    = _sysconf (unistd._SC_PAGESIZE),
     SAVED_IDS   = _sysconf (unistd._SC_SAVED_IDS),
     STREAM_MAX  = _sysconf (unistd._SC_STREAM_MAX),
     TZNAME_MAX  = _sysconf (unistd._SC_TZNAME_MAX),

--- a/specs/posix_compat_spec.yaml
+++ b/specs/posix_compat_spec.yaml
@@ -783,6 +783,9 @@ specify posix.compat:
   - it fetches the maximum number of open descriptors:
       expect (type (sysconf ().OPEN_MAX)).to_be "number"
       expect (sysconf "OPEN_MAX" >= 0).to_be (true)
+  - it fetches the size of memory pages:
+      expect (type (sysconf ().PAGESIZE)).to_be "number"
+      expect (sysconf "PAGESIZE" >= 0).to_be (true)
   - it fetches the number of saved ids:
       expect (type (sysconf ().SAVED_IDS)).to_be "number"
       expect (sysconf "SAVED_IDS" >= 0).to_be (true)

--- a/specs/posix_unistd_spec.yaml
+++ b/specs/posix_unistd_spec.yaml
@@ -197,6 +197,8 @@ specify posix.unistd:
       expect (type (sysconf (unistd._SC_NGROUPS_MAX))).to_be "number"
   - it fetches the maximum number of open descriptors:
       expect (type (sysconf (unistd._SC_OPEN_MAX))).to_be "number"
+  - it fetches the size of memory pages:
+      expect (type (sysconf (unistd._SC_PAGESIZE))).to_be "number"
   - it fetches the number of saved ids:
       expect (type (sysconf (unistd._SC_SAVED_IDS))).to_be "number"
   - it fetches the maximum number of open streams:


### PR DESCRIPTION
I missed this variable in LuaPosix, when interpreting values from /proc on Linux (thought I'd do the right thing rather than hardcoding a number). sysconf(3) says _SC_PAGESIZE is POSIX.1, so I hope there are no portability issues. Thanks for considering!