### PR TITLE
Allow users to call glob(3) with GLOB_MARK flag

### DIFF
--- a/ext/posix/glob.c
+++ b/ext/posix/glob.c
@@ -38,9 +38,12 @@ Pglob(lua_State *L)
 {
 	const char *pattern = optstring(L, 1, "*");
 	glob_t globres;
+	int glob_mark = 0;
+	if (lua_toboolean(L, 2))
+		glob_mark = GLOB_MARK;
 
-	checknargs(L, 1);
-	if (glob(pattern, 0, NULL, &globres))
+	checknargs(L, 2);
+	if (glob(pattern, glob_mark, NULL, &globres))
 		return pusherror(L, pattern);
 	else
 	{


### PR DESCRIPTION
Most of the optional flags for glob wouldn't make much sense for Lua,
but GLOB_MARK is very useful and would require a lot of work for a user
of luaposix to add after the fact. When GLOB_MARK is added to a call of
glob, directories are automatically given a final '/' in the list of
return values.

The function signature changes from glob([pattern]) to glob([pattern],
[glob_mark]). Any truthy value passed as a second argument turns on
GLOB_MARK. The second argument is optional, and the flag defaults to
false. So users who don't want this extra can simply ignore it, and they
can contingue to call the function as glob() and get the shortcut for
the "*" pattern.

I also moved checknargs to the top of Pglob on the theory of "fail
fast".

I haven't added tests yet. If there's interest in this patch, I'll spend
a little time learning specl and do so. (Looks like tests for glob
should go in spects/posix_spec.yaml, yes?)