### PR TITLE
Allow users to use GLOB_MARK flag with glob()

### DIFF
--- a/ext/posix/glob.c
+++ b/ext/posix/glob.c
@@ -29,6 +29,7 @@
 Find all files in this directory matching a shell pattern.
 @function glob
 @string[opt="*"] pat shell glob pattern
+@param flags currently limited to posix.glob.GLOB_MARK
 @treturn table matching filenames
 @see glob(3)
 @see glob.lua
@@ -37,10 +38,11 @@ static int
 Pglob(lua_State *L)
 {
 	const char *pattern = optstring(L, 1, "*");
+	int flags = checkint(L, 2);
 	glob_t globres;
 
-	checknargs(L, 1);
-	if (glob(pattern, 0, NULL, &globres))
+	checknargs(L, 2);
+	if (glob(pattern, flags, NULL, &globres))
 		return pusherror(L, pattern);
 	else
 	{
@@ -70,6 +72,7 @@ luaopen_posix_glob(lua_State *L)
 	luaL_register(L, "posix.glob", posix_glob_fns);
 	lua_pushliteral(L, "posix.glob for " LUA_VERSION " / " PACKAGE_STRING);
 	lua_setfield(L, -2, "version");
+	LPOSIX_CONST( GLOB_MARK );
 
 	return 1;
 }

--- a/lib/posix.lua.in
+++ b/lib/posix.lua.in
@@ -519,5 +519,45 @@ if _DEBUG ~= false then
   end
 end
 
+--- Find all files in this directory matching a shell pattern.
+-- The flag MARK appends a trailing slash to matches that are directories.
+-- @function glob
+-- @tparam table|string|nil args the three possible parameters can be used to
+-- override the default values for `pattern` and `MARK`, which are `"*"` and
+-- `false` respectively. A table will be checked for optional keys `pattern`
+-- and `MARK`. A string will be used as the glob pattern.
+-- @treturn table matching files and directories
+local posix_glob = require "posix.glob"
+
+local function glob (args)
+  -- Support previous `glob ".*"` style calls.
+  if type(args) == "string" then
+    args = {pattern=args}
+  elseif type(args) ~= "table" then
+    args = {}
+  end
+  local flags = 0
+  if args.MARK then
+    flags = posix_glob.GLOB_MARK
+  end
+  return posix_glob.glob(args.pattern, flags)
+end
+
+if _DEBUG ~= false then
+  local validtypes = { ["table"] = true, ["string"] = true, ["nil"] = true }
+
+  M.glob = function (...)
+    local argt = {...}
+    local argtype = type(argt[1])
+    if validtypes[argtype] ~= true then
+      argtypeerror ("glob", 1, "table, string or nil", argt[1])
+    elseif #argt > 1 then
+      toomanyargerror ("glob", 1, #argt)
+    end
+    return glob (...)
+  end
+else
+  M.glob = glob
+end
 
 return M

--- a/specs/posix_glob_spec.yaml
+++ b/specs/posix_glob_spec.yaml
@@ -1,0 +1,81 @@
+specify posix.glob:
+
+- before:
+    glob = require "posix.glob"
+
+- describe glob.GLOB_MARK:
+  - before:
+      MARK = glob.GLOB_MARK
+
+  - it is an number:
+      expect (type(MARK)).to_be "number"
+
+- describe glob:
+  - before:
+      glob, MARK = glob.glob, glob.GLOB_MARK
+      chdir, mkdir, mkdtemp = posix.chdir, posix.mkdir, posix.mkdtemp
+
+  - context with bad arguments:
+      badargs.diagnose (glob, "(?string, int)")
+
+  - it returns nil and an error message if there are no matches:
+      dir = mkdtemp (template)
+      chdir (dir)
+      globlist, errmsg = glob("foo", 0)
+      expect (type(errmsg)).to_be "string"
+      expect (errmsg).to_be("foo:" .. " No such file or directory")
+      expect (type(globlist)).to_be "nil"
+      rmtmp (dir)
+
+  - it returns a table of matches:
+      dir = mkdtemp (template)
+      chdir (dir)
+      touch ("match")
+      globlist = glob("*", 0)
+      expect (type(globlist)).to_be "table"
+      rmtmp (dir)
+
+  - it matches files in the current directory:
+      dir = mkdtemp (template)
+      chdir (dir)
+      touch ("test.1")
+      touch ("test.2")
+      touch ("extra_file")
+      globlist = glob("test.*", 0)
+      expect (type(globlist)).to_be "table"
+      expect (globlist).to_equal {"test.1", "test.2"}
+      rmtmp (dir)
+
+  - it matches files and directories in the current directory:
+      dir = mkdtemp (template)
+      chdir (dir)
+      touch ("test.1")
+      touch ("test.2")
+      mkdir ("foo")
+      mkdir ("bar")
+      globlist = glob("*", 0)
+      expect (type(globlist)).to_be "table"
+      expect (globlist).to_equal {"bar", "foo", "test.1", "test.2"}
+      rmtmp (dir)
+
+  - it uses '*' as the pattern if pattern is nil:
+      dir = mkdtemp (template)
+      chdir (dir)
+      touch ("test.1")
+      touch ("test.2")
+      mkdir ("foo")
+      mkdir ("bar")
+      globlist = glob(nil, 0)
+      expect (type(globlist)).to_be "table"
+      expect (globlist).to_equal {"bar", "foo", "test.1", "test.2"}
+      rmtmp (dir)
+
+  - it adds '/' to directory names if GLOB_MARK is passed:
+      dir = mkdtemp (template)
+      chdir (dir)
+      mkdir ("foo")
+      mkdir ("bar")
+      globlist = glob(nil, MARK)
+      expect (type(globlist)).to_be "table"
+      expect (globlist).to_equal {"bar/", "foo/"}
+      rmtmp (dir)

--- a/specs/posix_spec.yaml
+++ b/specs/posix_spec.yaml
@@ -478,9 +478,10 @@ specify posix:
   - describe glob:
     - before:
         chdir, glob, mkdtemp = posix.chdir, posix.glob, posix.mkdtemp
+        mkdir = posix.mkdir
 
     - context with bad arguments:
-        badargs.diagnose (glob, "(?string)")
+        badargs.diagnose (glob, "(?table|string)")
 
     - it matches files in the given directory:
         dir = mkdtemp (template)
@@ -491,8 +492,36 @@ specify posix:
         globlist, errmsg = glob "test.*"
         expect (errmsg).to_be (nil)
         expect (type (globlist)).to_be "table"
+        expect (globlist).to_equal {"test.1", "test.2"}
         rmtmp (dir)
 
+    - it matches files and directories in the given directory:
+        dir = mkdtemp (template)
+        touch (dir .. "/test.1")
+        chdir (dir)
+        mkdir ("foo")
+        mkdir ("bar")
+        globlist = glob()
+        expect (globlist).to_equal {"bar", "foo", "test.1"}
+        rmtmp (dir)
+
+    - it adds / to filenames if GLOB_MARK is true:
+        dir = mkdtemp (template)
+        chdir (dir)
+        mkdir ("foo")
+        mkdir ("bar")
+        globlist = glob({pattern="*", MARK=true})
+        expect (globlist).to_equal {"bar/", "foo/"}
+        rmtmp (dir)
+
+    - it does not add / to filenames if GLOB_MARK is false:
+        dir = mkdtemp (template)
+        chdir (dir)
+        mkdir ("foo")
+        mkdir ("bar")
+        globlist = glob({MARK=false})
+        expect (globlist).to_equal {"bar", "foo"}
+        rmtmp (dir)
 
   - describe files:
     - before:

--- a/specs/specs.mk
+++ b/specs/specs.mk
@@ -31,6 +31,7 @@ specl_SPECS =						\
 	$(srcdir)/specs/posix_time_spec.yaml		\
 	$(srcdir)/specs/posix_unistd_spec.yaml		\
 	$(srcdir)/specs/posix_spec.yaml			\
+	$(srcdir)/specs/posix_glob_spec.yaml		\
 	$(NOTHING_ELSE)
 
 EXTRA_DIST +=						\


### PR DESCRIPTION
Most of the optional flags for glob wouldn't make much sense for Lua,
but GLOB_MARK is very useful and would require a lot of work for a user
of luaposix to add after the fact. (When GLOB_MARK is added to a call of
glob, directories are automatically given a final '/' in the list of
return values.)

The function signature changes from glob([pattern]) to glob([pattern],
[glob_mark]). Any truthy value passed as a second argument turns on
GLOB_MARK. The second argument is optional, and the flag defaults to
false. So users who don't want this extra can simply ignore it, and they
can contingue to call the function as glob() and get the shortcut for
the "*" pattern.

I haven't added tests yet. If there's interest in this patch, I'll spend
a little time learning specl and do so. (Looks like tests for glob
should go in spects/posix_spec.yaml, yes?)