### PR TITLE
Add linkat(2) support

### DIFF
--- a/ext/posix/fcntl.c
+++ b/ext/posix/fcntl.c
@@ -197,6 +197,11 @@ Fcntl constants.
 Any constants not available in the underlying system will be `0` valued,
 if they are usually bitwise ORed with other values, otherwise `nil`.
 @table posix.fcntl
+@int AT_EACCESS test access permitted for effective IDs, not real IDs
+@int AT_FDCWD indicate *at functions to use current directory
+@int AT_REMOVEDIR remove directory instead of unlinking file
+@int AT_SYMLINK_FOLLOW follow symbolic links
+@int AT_SYMLINK_NOFOLLOW do not follow symbolic links
 @int FD_CLOEXEC close file descriptor on exec flag
 @int F_DUPFD duplicate file descriptor
 @int F_GETFD get file descriptor flags
@@ -245,6 +250,23 @@ luaopen_posix_fcntl(lua_State *L)
 	luaL_register(L, "posix.fcntl", posix_fcntl_fns);
 	lua_pushstring(L, LPOSIX_VERSION_STRING("fcntl"));
 	lua_setfield(L, -2, "version");
+
+	/* posix *at flags */
+#ifdef AT_EACCESS
+	LPOSIX_CONST( AT_EACCESS		);
+#endif
+#ifdef AT_FDCWD
+	LPOSIX_CONST( AT_FDCWD			);
+#endif
+#ifdef AT_REMOVEDIR
+	LPOSIX_CONST( AT_REMOVEDIR		);
+#endif
+#ifdef AT_SYMLINK_FOLLOW
+	LPOSIX_CONST( AT_SYMLINK_FOLLOW		);
+#endif
+#ifdef AT_SYMLINK_NOFOLLOW
+	LPOSIX_CONST( AT_SYMLINK_NOFOLLOW	);
+#endif
 
 	/* fcntl flags */
 	LPOSIX_CONST( FD_CLOEXEC	);

--- a/ext/posix/fcntl.c
+++ b/ext/posix/fcntl.c
@@ -267,6 +267,13 @@ luaopen_posix_fcntl(lua_State *L)
 #ifdef AT_SYMLINK_NOFOLLOW
 	LPOSIX_CONST( AT_SYMLINK_NOFOLLOW	);
 #endif
+	/* Linux-specific *at flags */
+#ifdef AT_EMPTY_PATH
+	LPOSIX_CONST( AT_EMPTY_PATH	);
+#endif
+#ifdef AT_NO_AUTOMOUNT
+	LPOSIX_CONST( AT_NO_AUTOMOUNT	);
+#endif
 
 	/* fcntl flags */
 	LPOSIX_CONST( FD_CLOEXEC	);

--- a/ext/posix/fcntl.c
+++ b/ext/posix/fcntl.c
@@ -18,9 +18,9 @@
 @module posix.fcntl
 */
 
-#include <fcntl.h>
-
 #include "_helpers.c"
+
+#include <fcntl.h>
 
 
 /* Darwin fails to define O_RSYNC. */

--- a/ext/posix/unistd.c
+++ b/ext/posix/unistd.c
@@ -791,6 +791,34 @@ Plink(lua_State *L)
 	return pushresult(L, (symbolicp ? symlink : link)(oldpath, newpath), NULL);
 }
 
+
+/***
+Create a link at specified directory.
+@function linkat
+@int targetdir fd
+@string target name
+@int linkdir fd
+@string link name
+@int flags
+@treturn[1] int `0`, if successful
+@return[2] nil
+@treturn[2] string error message
+@treturn[2] int errnum
+@see linkat(2)
+*/
+static int
+Plinkat(lua_State *L)
+{
+	int olddirfd = checkint(L, 1);
+	const char *oldpath = luaL_checkstring(L, 2);
+	int newdirfd = checkint(L, 3);
+	const char *newpath = luaL_checkstring(L, 4);
+	int flags = checkint(L, 5);
+	checknargs(L, 5);
+	return pushresult(L, linkat(olddirfd, oldpath, newdirfd, newpath, flags), NULL);
+}
+
+
 /***
 reposition read/write file offset
 @function lseek
@@ -1280,6 +1308,7 @@ static const luaL_Reg posix_unistd_fns[] =
 	LPOSIX_FUNC( Plchown		),
 #endif
 	LPOSIX_FUNC( Plink		),
+	LPOSIX_FUNC( Plinkat		),
 	LPOSIX_FUNC( Plseek		),
 	LPOSIX_FUNC( Pnice		),
 	LPOSIX_FUNC( Ppathconf		),

--- a/specs/posix_unistd_spec.yaml
+++ b/specs/posix_unistd_spec.yaml
@@ -189,6 +189,51 @@ specify posix.unistd:
       badargs.diagnose (unistd.lchown, "(string, ?string|int, ?string|int)")
 
 
+- describe link:
+  - before:
+      link = unistd.link
+
+      st = require "posix.sys.stat"
+      lstat = st.lstat
+      S_ISREG, S_ISLNK = st.S_ISREG, st.S_ISLNK
+
+      dir = posix.mkdtemp (template)
+      touch (dir .. "/file")
+
+  - after:
+      rmtmp (dir)
+
+  - context with bad arguments:
+      badargs.diagnose (link, "(string, string, ?boolean)")
+
+  - it creates hard link without optional param:
+      st_before = lstat (dir .. "/file")
+      link (dir .. "/file", dir .. "/hard")
+      st_after = lstat (dir .. "/file")
+      st_link = lstat (dir .. "/hard")
+      expect (st_before.st_nlink + 1).to_be(st_after.st_nlink)
+      expect (st_after.st_nlink).to_be(st_link.st_nlink)
+      expect (S_ISREG (st_link.st_mode)).not_to_be(0)
+      expect (S_ISLNK (st_link.st_mode)).to_be(0)
+  - it creates hard link with optional param:
+      st_before = lstat (dir .. "/file")
+      link (dir .. "/file", dir .. "/hard", false)
+      st_after = lstat (dir .. "/file")
+      st_link = lstat (dir .. "/hard")
+      expect (st_before.st_nlink + 1).to_be(st_after.st_nlink)
+      expect (st_after.st_nlink).to_be(st_link.st_nlink)
+      expect (S_ISREG (st_link.st_mode)).not_to_be(0)
+      expect (S_ISLNK (st_link.st_mode)).to_be(0)
+  - it creates soft link:
+      st_before = lstat (dir .. "/file")
+      link (dir .. "/file", dir .. "/soft", true)
+      st_after = lstat (dir .. "/file")
+      st_link = lstat (dir .. "/soft")
+      expect (st_before.st_nlink).to_be(st_after.st_nlink)
+      expect (S_ISREG (st_link.st_mode)).to_be(0)
+      expect (S_ISLNK (st_link.st_mode)).not_to_be(0)
+
+
 - describe pathconf:
   - before:
       pathconf = unistd.pathconf

--- a/specs/posix_unistd_spec.yaml
+++ b/specs/posix_unistd_spec.yaml
@@ -234,6 +234,68 @@ specify posix.unistd:
       expect (S_ISLNK (st_link.st_mode)).not_to_be(0)
 
 
+- describe linkat:
+  - before:
+      linkat = unistd.linkat
+      link = unistd.link
+
+      st = require "posix.sys.stat"
+      lstat = st.lstat
+      S_ISREG, S_ISLNK = st.S_ISREG, st.S_ISLNK
+
+      AT_FDCWD, AT_SYMLINK_FOLLOW = fcntl.AT_FDCWD, fcntl.AT_SYMLINK_FOLLOW
+
+      dir = posix.mkdtemp (template)
+      touch (dir .. "/file")
+      dirfd = fcntl.open(dir, fcntl.O_RDONLY)
+
+  - after:
+      unistd.close (dirfd)
+      rmtmp (dir)
+
+  - context with bad arguments:
+      badargs.diagnose (linkat, "(int, string, int, string, int)")
+
+  - it creates hard link using AT_FDCWD:
+      st_before = lstat (dir .. "/file")
+      linkat (AT_FDCWD, dir .. "/file", AT_FDCWD, dir .. "/hard", 0)
+      st_after = lstat (dir .. "/file")
+      st_link = lstat (dir .. "/hard")
+      expect (st_before.st_nlink + 1).to_be(st_after.st_nlink)
+      expect (st_after.st_nlink).to_be(st_link.st_nlink)
+      expect (S_ISREG (st_link.st_mode)).not_to_be(0)
+  - it creates hard link in directory specified by fd:
+      st_before = lstat (dir .. "/file")
+      linkat (dirfd, "file", dirfd, "hard", 0)
+      st_after = lstat (dir .. "/file")
+      st_link = lstat (dir .. "/hard")
+      expect (st_before.st_nlink + 1).to_be(st_after.st_nlink)
+      expect (st_after.st_nlink).to_be(st_link.st_nlink)
+      expect (S_ISREG (st_link.st_mode)).not_to_be(0)
+  - it creates hard link to file symbolic link:
+      link (dir .. "/file", dir .. "/soft", true)
+      st_before = lstat (dir .. "/file")
+      linkat (dirfd, "soft", dirfd, "hard", 0)
+      st_after = lstat (dir .. "/file")
+      st_hard = lstat (dir .. "/hard")
+      st_soft = lstat (dir .. "/soft")
+      expect (st_before.st_nlink).to_be(st_after.st_nlink)
+      expect (st_soft.st_nlink).to_be(st_hard.st_nlink)
+      expect (S_ISREG (st_hard.st_mode)).to_be(0)
+      expect (S_ISLNK (st_hard.st_mode)).not_to_be(0)
+  - it creates hard link to file referenced by symbolic link:
+      link (dir .. "/file", dir .. "/soft", true)
+      st_before = lstat (dir .. "/file")
+      linkat (dirfd, "soft", dirfd, "hard", AT_SYMLINK_FOLLOW)
+      st_after = lstat (dir .. "/file")
+      st_hard = lstat (dir .. "/hard")
+      st_soft = lstat (dir .. "/soft")
+      expect (st_before.st_nlink + 1).to_be(st_after.st_nlink)
+      expect (st_after.st_nlink).to_be(st_hard.st_nlink)
+      expect (S_ISREG (st_hard.st_mode)).not_to_be(0)
+      expect (S_ISLNK (st_hard.st_mode)).to_be(0)
+
+
 - describe pathconf:
   - before:
       pathconf = unistd.pathconf


### PR DESCRIPTION
Hi,

This pull request mainly adds support for linkat(2). Additionally it introduces AT_* constants from fcntl.h, so they can be used in future for all *at() functions.

specl tests were added for link(2) and linkat(2).

First commit however reorders includes in fcntl, so all platform-specific stuff is properly enabled using feature_test_macros. This is used in introduced Linux-specific AT_* constants and is also neccessary to properly export O_TMPFILE (introduced lately).