### PR TITLE
added handling for WNOHANG

### DIFF
--- a/ext/posix/sys/wait.c
+++ b/ext/posix/sys/wait.c
@@ -46,7 +46,11 @@ Pwait(lua_State *L)
 	if (pid == -1)
 		return pusherror(L, NULL);
 	lua_pushinteger(L, pid);
-	if (WIFEXITED(status))
+	if(pid == 0){
+		lua_pushliteral(L,"running");
+		return 2
+	}
+	else if (WIFEXITED(status))
 	{
 		lua_pushliteral(L,"exited");
 		lua_pushinteger(L, WEXITSTATUS(status));

--- a/ext/posix/sys/wait.c
+++ b/ext/posix/sys/wait.c
@@ -48,7 +48,7 @@ Pwait(lua_State *L)
 	lua_pushinteger(L, pid);
 	if(pid == 0){
 		lua_pushliteral(L,"running");
-		return 2
+		return 2;
 	}
 	else if (WIFEXITED(status))
 	{


### PR DESCRIPTION
There was a misleading return of state if you passed WNOHANG, it returned "exited". But waitpid() returns 0, which means that nothing happened. So I added an extra state "running", which is now returned instead of "exited"

Fixed syntax error from previous pr #291 