### PR TITLE
Replace luaL_register with luaL_newlib

### DIFF
--- a/ext/include/_helpers.c
+++ b/ext/include/_helpers.c
@@ -72,8 +72,6 @@
 #if LUA_VERSION_NUM == 502 || LUA_VERSION_NUM == 503
 #  define lua_objlen lua_rawlen
 #  define lua_strlen lua_rawlen
-#  define luaL_openlib(L,n,l,nup) luaL_setfuncs((L),(l),(nup))
-#  define luaL_register(L,n,l) (luaL_newlib(L,l))
 #endif
 
 #define _LPOSIX_VERSION_STRING(m) 					\


### PR DESCRIPTION
This patch disables setting of `posix` global table, instead
it will register all functions into the table on the top of the stack.

```
luaL_newlib works like:

  lua_newtable(L)
  luaL_register(L, NULL, funcs)
```

test.lua: 
```
setmetatable(_G, {
  __newindex = function (t, n, v)
    print('setting', n)
    rawset(t, n, v)
  end
})

local wait = require 'posix.sys.wait'
```

```
# without patch
$ ./test.lua
setting posix

# with patch
$ ./test.lua
```

Tested on Linux, with Luajit 2.1 beta3 and Lua 5.1, should work with 5.2/5.3.

Thanks!