### PR TITLE
Don't include grp.h and pwd.h in _helpers.c

### DIFF
--- a/ext/include/_helpers.c
+++ b/ext/include/_helpers.c
@@ -35,8 +35,6 @@
 #endif
 
 #include <errno.h>
-#include <grp.h>
-#include <pwd.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/stat.h>

--- a/ext/posix/unistd.c
+++ b/ext/posix/unistd.c
@@ -23,6 +23,8 @@
 #endif
 #include <sys/stat.h>
 #include <sys/types.h>
+#include <grp.h>
+#include <pwd.h>
 #include <unistd.h>
 
 #include "_helpers.c"


### PR DESCRIPTION
_helpers.c does not need these headers.

I use a subset of luaposix with mingw. When _helpers.c includes these files it won't build because mingw does not provide these headers. Because they are not needed in _helpers.c it does not make sense to have them in there.