### PR TITLE
maint: additional boundary condition for posix.signal.signal

### DIFF
--- a/ext/posix/signal.c
+++ b/ext/posix/signal.c
@@ -15,7 +15,12 @@
  Constants and functions for propagating signals among processes.
 
  Note that `posix.signal.signal` is implemented with sigaction(2) for
- consistent semantics across platforms.
+ consistent semantics across platforms. Also note that installed signal
+ handlers are not called immediatly upon occurrence of a signal. Instead,
+ in order to keep the interperter state clean, they are executed in the
+ context of a debug hook which is called as soon as the interpreter enters
+ a new function, returns from the currently executing function, or after the
+ execution of the current instruction has ended.
 
 @module posix.signal
 */


### PR DESCRIPTION
It took me quite some time to understand, that installed signal handlers are not called immediately. :-)

I was using a Lua-Wrapper around libpcap which exposes the `pcap_loop` function which is blocking. In order to unblock and return from it, one has to call `pcap_breakloop` which is typically performed from within a signal handler. Now that the `pcap_loop` call is blocking, the installed hook (via `lua_sethook`) never gets executed.