### PR TITLE
unistd: accept optional nbytes and buf_offset arguments to write.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -25,10 +25,14 @@
     prevents access to the preloaded `require 'posix'.fcntl.fcntl`
     binding.
 
-  - `posix.unistd.write` takes an optional third argument `nbytes`
-    to conform better to the SUSv3 specification.  For backwards
-    compatibility, the entirety of `buf` is written when a third
-    argument is not passed (or is `nil`).
+### New Features
+
+  - `posix.unistd.write` takes an optional third argument `nbytes` to
+    conform better to the SUSv3 specification, and an optional fourth
+    argument `buf_offset` to allow efficent writing of a substring of
+    `buf`.  For backwards compatibility, the entirety of `buf` is
+    written when the third and fourth arguments are not passed (or are
+    `nil`).
 
 
 ## Noteworthy changes in release 35.1 (2021-09-09) [stable]

--- a/ext/posix/unistd.c
+++ b/ext/posix/unistd.c
@@ -1252,7 +1252,7 @@ Pwrite(lua_State *L)
 	}
 
 	if (buf_offset && lua_type(L, 3) == LUA_TNIL)
-		nbytes -= buf_offset;
+		nbytes = buf_len - buf_offset;
 
 	if (buf_offset + nbytes > buf_len)
 	{

--- a/spec/posix_spec.yaml
+++ b/spec/posix_spec.yaml
@@ -316,7 +316,7 @@ specify posix:
 
   - describe write:
     - context with bad arguments:
-        badargs.diagnose(M.write, "(int, string, ?int)")
+        badargs.diagnose(M.write, "(int, string, ?int, ?int)")
 
 
   - describe fcntl:


### PR DESCRIPTION
* ext/posix/unistd.c (Pwrite): Accept an optional third nbytes parameter, and an optional fourth buf_offset_parameter.  Perform bounds checking.
* spec/posix_spec.yaml (write): Update specification.
* NEWS.md (New features): Update.