### PR TITLE
posix.termio: add missing termios.IUTF8

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -32,6 +32,10 @@
 
         local stat  = require 'posix.sys.stat'.stat
 
+  - Removed `IUTF8` from the documented list of supported `iflag`
+    values in `posix.termios` because it was previously
+    unimplemented. Implemented non-portable support as an XSI
+    extension, as it isn't a part of the POSIX standard.
 
 ## Noteworthy changes in release 36.1 (2023-01-31) [stable]
 

--- a/ext/posix/termio.c
+++ b/ext/posix/termio.c
@@ -51,7 +51,7 @@ as long as they are supported by the underlying system.
   `PARODD`, `HUPCL`, `CLOCAL` and `CRTSCTS`
 @int iflag input flags; bitwise OR of zero or more of `IGNBRK`, `BRKINT`,
   `IGNPAR`, `PARMRK`, `INPCK`, `ISTRIP`, `INLCR`, `IGNCR`, `ICRNL`,
-  `IXON`, `IXOFF`, `IXANY`, `IMAXBEL` and `IUTF8`
+  `IXON`, `IXOFF`, `IXANY`, and `IMAXBEL`
 @int lflag local flags; bitwise OR of zero or more of `ISIG`, `ICANON`,
   `ECHO`, `ECHOE`, `ECHOK', 'ECHONL`, `NOFLSH`, `IEXTEN` and `TOSTOP`
 @int oflag output flags; bitwise OR of zero or more of `OPOST`, `ONLCR`,
@@ -586,6 +586,9 @@ luaopen_posix_termio(lua_State *L)
 #endif
 #ifdef FLUSHO
 	LPOSIX_CONST( FLUSHO		);
+#endif
+#ifdef IUTF8
+	LPOSIX_CONST( IUTF8		);
 #endif
 #ifdef PENDIN
 	LPOSIX_CONST( PENDIN		);


### PR DESCRIPTION
`termio.IUTF8` was documented as a usable constant, but the corresponding `#ifdef` was missing, so I went ahead and added it.

Sorry for the lack of tests - I didn't see anywhere there were already tests for the various flags, so I didn't want to create one from whole cloth. However, I *did* build locally and try getting/setting `IUTF8` and it works as expected.

Thanks!