### PR TITLE
Clarify doc for getgrgid/getgrnam/getpwuid/getpwnam when the group/user does not exist

### DIFF
--- a/ext/posix/grp.c
+++ b/ext/posix/grp.c
@@ -104,9 +104,10 @@ Fetch group with given group id.
 @function getgrgid
 @int gid group id
 @treturn[1] PosixGroup group record for *gid*, if successful
-@return[2] nil
-@treturn[2] string error message
-@treturn[2] int errnum
+@return[2] nil, if the group does not exist
+@return[3] nil
+@treturn[3] string error message
+@treturn[3] int errnum
 @see getgrgid(3)
 @usage
   local grp = require "posix.grp"
@@ -132,9 +133,10 @@ Fetch named group.
 @function getgrnam
 @string name group name
 @treturn[1] PosixGroup group record for *name*, if successful
-@return[2] nil
-@treturn[2] string error message
-@treturn[2] int errnum
+@return[2] nil, if the group does not exist
+@return[3] nil
+@treturn[3] string error message
+@treturn[3] int errnum
 @see getgrnam(3)
 @usage
   local grp = require "posix.grp"

--- a/ext/posix/pwd.c
+++ b/ext/posix/pwd.c
@@ -100,9 +100,10 @@ Fetch named user.
 @function getpwnam
 @string name user name
 @treturn[1] PosixPasswd passwd record for *name*, if successful
-@return[2] nil
-@treturn[2] string error message
-@treturn[2] int errnum
+@return[2] nil, if the user does not exist
+@return[3] nil
+@treturn[3] string error message
+@treturn[3] int errnum
 @see getpwnam(3)
 @usage
   local pwd = require "posix.pwd"
@@ -128,9 +129,10 @@ Fetch password entry with given user id.
 @function getpwuid
 @int uid user id
 @treturn[1] PosixPasswd passwd record for *uid*, if successful
-@return[2] nil
-@treturn[2] string error message
-@treturn[2] int errnum
+@return[2] nil, if the user does not exist
+@return[3] nil
+@treturn[3] string error message
+@treturn[3] int errnum
 @see getpwuid(3)
 @usage
   local pwd = require "posix.pwd"


### PR DESCRIPTION
The posix spec says that the C functions should return NULL and not change errno when the group/user does not exist.

The wrappers set errno to 0 before the call, so the current expected behavior when the group/user does not exist _is_ to return a single nil
The doc has been updated to reflect that

The C functions are used in a few other places, but they treat a missing group/user and an error in the same way, so it's fine

The wrappers are not reused anywhere

The lua functions are only used in tests and there are already tests for this special case

