### PR TITLE
Update msg.c

### DIFF
--- a/ext/posix/sys/msg.c
+++ b/ext/posix/sys/msg.c
@@ -33,6 +33,9 @@
 #include <sys/msg.h>
 #include <sys/types.h>
 
+#ifndef msglen_t
+  #define msglen_t unsgined long
+#endif
 
 /***
 Message queue record.


### PR DESCRIPTION
ADD a preprocessor directive to check whether "msglen_t" has been defined. Otherwise, define the new type as an alias for "unsigned long".