### PR TITLE
Adds tcgetwinsize and tcsetwinsize functions

### DIFF
--- a/spec/posix_spec.yaml
+++ b/spec/posix_spec.yaml
@@ -934,6 +934,13 @@ specify posix:
     - context with bad arguments:
         badargs.diagnose(M.tcflow, "(int, int)")
 
+  - describe tcgetwinsize:
+    - context with bad arguments:
+        badargs.diagnose(M.tcgetwinsize, "(int)")
+
+  - describe tcsetwinsize:
+    - context with bad arguments:
+        badargs.diagnose(M.tcsetwinsize, "(int, table)")
 
 
 - specify user management:


### PR DESCRIPTION
Implement two new Lua-accessible functions in termio.c:
  - tcgetwinsize(fd): wraps TIOCGWINSZ to retrieve terminal window size
  - tcsetwinsize(fd, ws): wraps TIOCSWINSZ to set terminal window size