### PR TITLE
Update github workflows spec.yml

### DIFF
--- a/.github/workflows/spec.yml
+++ b/.github/workflows/spec.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        lua-version: ["5.4", "5.3", "5.2", "5.1", "luajit"]
+        lua-version: ["5.4", "5.3", "5.2", "5.1", "luajit-openresty"]
         strict: ["std.strict", ""]
 
     runs-on: ubuntu-latest

--- a/.github/workflows/spec.yml
+++ b/.github/workflows/spec.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        lua-version: ["5.4", "5.3", "5.2", "5.1", "luajit-openresty"]
+        lua-version: ["5.4", "5.3", "5.2", "5.1", "luajit"]
         strict: ["std.strict", ""]
 
     runs-on: ubuntu-latest
@@ -19,11 +19,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: leafo/gh-actions-lua@v10
+      - uses: luarocks/gh-actions-lua@v10
         with:
           luaVersion: ${{ matrix.lua-version }}
 
-      - uses: leafo/gh-actions-luarocks@v4
+      - uses: luarocks/gh-actions-luarocks@v5
 
       - name: install
         run: |

--- a/.github/workflows/spec.yml
+++ b/.github/workflows/spec.yml
@@ -19,11 +19,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: leafo/gh-actions-lua@v8.0.0
+      - uses: leafo/gh-actions-lua@v10
         with:
           luaVersion: ${{ matrix.lua-version }}
 
-      - uses: leafo/gh-actions-luarocks@v4.0.0
+      - uses: leafo/gh-actions-luarocks@v4
 
       - name: install
         run: |


### PR DESCRIPTION
switch to luarocks forks of gh-actions-lua and gh-actions-luarocks, which should cope better with luajit rolling releases.